### PR TITLE
Build game phases dynamically from role registry

### DIFF
--- a/game_logic.py
+++ b/game_logic.py
@@ -298,51 +298,16 @@ def hat_spieler_mit_rolle(raum: Raum, rolle: str) -> bool:
 def phasennamen_zu_rollen_mapping() -> dict:
     """
     Erstellt ein Mapping zwischen Phasennamen und erforderlichen Rollen.
-    
+
     Returns:
         Dictionary mit Phase zu Rolle Mapping
     """
-    return {
-        'dieb_phase': 'Dieb',
-        'doppelgaenger_phase': 'Doppelgänger',
-        'armor_phase': 'Amor',
-        'priester_dunkel_phase': 'Dunkler Priester',
-        'wildes_kind_phase': 'Wildes Kind',
-        'hund_phase': 'Hund',
-        'schwestern_phase': 'Zwei Schwestern',
-        'brueder_phase': 'Drei Brüder',
-        'freimaurer_phase': 'Freimaurer',
-        'fluechtlinge_phase': 'Flüchtlinge',
-        'sandmann_phase': 'Sandmann',
-        'seherin_phase': 'Seherin',
-        'seherlehrling_phase': 'Seherlehrling',
-        'aurenseherin_phase': 'Aurenseherin',
-        'medium_phase': 'Medium',
-        'tratschweib_phase': 'Tratschweib',
-        'paranormal_billig_phase': 'Paranormaler Ermittler (billig)',
-        'werwolfseherin_phase': 'Werwolfseherin',
-        'heiler_phase': 'Heiler',
-        'leibwaechter_phase': 'Leibwächter',
-        'hure_phase': 'Hure',
-        'prostituierte_phase': 'Prostituierte',
-        'nutte_phase': 'Nutte',
-        'einsamerwolf_phase': 'Einsamer Wolf',
-        'urwolf_phase': 'Urwolf',
-        'weisser_wolf_phase': 'Weißer Wolf',
-        'mordlustiger_phase': 'Mordlustiger',
-        'hexe_phase': 'Hexe',
-        'hexenmeister_phase': 'Hexenmeister',
-        'giftmischerin_phase': 'Giftmischerin',
-        'kraeuterweib_phase': 'Kräuterweib',
-        'zauberer_phase': 'Zauberer',
-        'zahnarzt_phase': 'Zahnarzt',
-        'rabe_phase': 'Rabe',
-        'floetenspieler_phase': 'Flötenspieler',
-        'vampir_phase': 'Vampir',
-        'zombie_phase': 'Zombie',
-        'pyromane_phase': 'Pyromane',
-        'tonks_phase': 'Tonks',
-        'buddler_phase': 'Buddler',
+    from roles import RoleRegistry
+
+    mapping = RoleRegistry.get_phase_role_mapping()
+
+    # Tag-/Spezial-Phasen, die nicht über nacht_aktiv erfasst werden
+    mapping.update({
         'baerenbaendiger_brummen': 'Bärenbändiger',
         'demoskopin_info': 'Demoskopin',
         'prinz_enthuellung': 'Prinz',
@@ -350,7 +315,9 @@ def phasennamen_zu_rollen_mapping() -> dict:
         'kamikaze_phase': 'Kamikaze',
         'hahn_enthuellung': 'Hahn',
         'putzfrau_info': 'Putzfrau',
-    }
+    })
+
+    return mapping
 
 
 def naechste_phase(raum: Raum) -> str:

--- a/game_logic.py
+++ b/game_logic.py
@@ -1,6 +1,7 @@
 """
 Spiellogik fuer das Werwolf-Spiel
 """
+
 import random
 from models import db, Raum, Spieler, SpielAktion, SpielLog, ROLLEN, PHASEN
 
@@ -8,32 +9,32 @@ from models import db, Raum, Spieler, SpielAktion, SpielLog, ROLLEN, PHASEN
 def berechne_rollen(spieler_anzahl: int, mit_erzaehler: bool = False) -> dict:
     """
     Berechnet die Rollenverteilung basierend auf der Spieleranzahl.
-    
+
     Balanced for games from 5 to 1000+ players.
-    
+
     Balance ratios (based on research):
     - Werewolves: ~20-22% of players (1 wolf per 4-5 villagers)
     - Special village roles: Scale with player count
     - Wolves:Villagers:Specials ratio around 1:2:1 to 1:3:1
     - Solo/neutral roles added sparingly in larger games
-    
+
     Args:
         spieler_anzahl: Anzahl der Spieler
         mit_erzaehler: Ob ein Erzaehler dabei ist
-        
+
     Returns:
         Dictionary mit Rollen und deren Anzahl
     """
     effektive_anzahl = spieler_anzahl - (1 if mit_erzaehler else 0)
-    
+
     if effektive_anzahl < 5:
         effektive_anzahl = 5  # Minimum players
-    
+
     rollen = {}
-    
+
     if mit_erzaehler:
-        rollen['Erzaehler'] = 1
-    
+        rollen["Erzaehler"] = 1
+
     # ========================================================================
     # WEREWOLF TEAM CALCULATION (Target: ~20-22% of players)
     # ========================================================================
@@ -49,197 +50,198 @@ def berechne_rollen(spieler_anzahl: int, mit_erzaehler: bool = False) -> dict:
     else:
         # For massive games (500+): ~15-18% wolves (voting power is strong)
         werwolf_basis = max(20, int(effektive_anzahl * 0.16))
-    
+
     # Add werewolf variants for large games
-    rollen['Werwolf'] = werwolf_basis
-    
+    rollen["Werwolf"] = werwolf_basis
+
     # Special werewolf roles (scale with game size)
     if effektive_anzahl >= 13:
-        rollen['Weißer Wolf'] = max(1, effektive_anzahl // 100)  # Solo wolf
+        rollen["Weißer Wolf"] = max(1, effektive_anzahl // 100)  # Solo wolf
     if effektive_anzahl >= 17:
-        rollen['Urwolf'] = max(1, effektive_anzahl // 150)
+        rollen["Urwolf"] = max(1, effektive_anzahl // 150)
     if effektive_anzahl >= 25:
-        rollen['Wolfsjunge'] = max(1, effektive_anzahl // 200)
+        rollen["Wolfsjunge"] = max(1, effektive_anzahl // 200)
     if effektive_anzahl >= 100:
-        rollen['Wolf im Schafspelz'] = max(1, effektive_anzahl // 150)
+        rollen["Wolf im Schafspelz"] = max(1, effektive_anzahl // 150)
     if effektive_anzahl >= 200:
-        rollen['Werwolfseherin'] = max(1, effektive_anzahl // 250)
+        rollen["Werwolfseherin"] = max(1, effektive_anzahl // 250)
     if effektive_anzahl >= 300:
-        rollen['Einsamer Wolf'] = max(1, effektive_anzahl // 400)
-    
+        rollen["Einsamer Wolf"] = max(1, effektive_anzahl // 400)
+
     # ========================================================================
     # VILLAGE SPECIAL ROLES (Scale to provide balance)
     # ========================================================================
     # Information roles (critical for village success in large games)
     if effektive_anzahl >= 5:
-        rollen['Seherin'] = max(1, effektive_anzahl // 50)  # 1 per 50 players
+        rollen["Seherin"] = max(1, effektive_anzahl // 50)  # 1 per 50 players
     if effektive_anzahl >= 6:
-        rollen['Hexe'] = max(1, effektive_anzahl // 75)  # Heals + kills
+        rollen["Hexe"] = max(1, effektive_anzahl // 75)  # Heals + kills
     if effektive_anzahl >= 8:
-        rollen['Amor'] = max(1, effektive_anzahl // 150)
+        rollen["Amor"] = max(1, effektive_anzahl // 150)
     if effektive_anzahl >= 10:
-        rollen['Jäger'] = max(1, effektive_anzahl // 60)  # Death trigger
+        rollen["Jäger"] = max(1, effektive_anzahl // 60)  # Death trigger
     if effektive_anzahl >= 12:
-        rollen['Heiler'] = max(1, effektive_anzahl // 80)  # Protection
-    
+        rollen["Heiler"] = max(1, effektive_anzahl // 80)  # Protection
+
     # More advanced roles for larger games
     if effektive_anzahl >= 15:
-        rollen['Alter Mann'] = max(1, effektive_anzahl // 100)
+        rollen["Alter Mann"] = max(1, effektive_anzahl // 100)
     if effektive_anzahl >= 18:
-        rollen['Medium'] = max(1, effektive_anzahl // 100)
+        rollen["Medium"] = max(1, effektive_anzahl // 100)
     if effektive_anzahl >= 20:
-        rollen['Rabe'] = max(1, effektive_anzahl // 120)
+        rollen["Rabe"] = max(1, effektive_anzahl // 120)
     if effektive_anzahl >= 25:
-        rollen['Prinz'] = max(1, effektive_anzahl // 150)
+        rollen["Prinz"] = max(1, effektive_anzahl // 150)
     if effektive_anzahl >= 30:
-        rollen['Bürgermeister'] = max(1, effektive_anzahl // 200)
+        rollen["Bürgermeister"] = max(1, effektive_anzahl // 200)
     if effektive_anzahl >= 35:
-        rollen['Leibwächter'] = max(1, effektive_anzahl // 150)
+        rollen["Leibwächter"] = max(1, effektive_anzahl // 150)
     if effektive_anzahl >= 40:
-        rollen['Aurenseherin'] = max(1, effektive_anzahl // 200)
+        rollen["Aurenseherin"] = max(1, effektive_anzahl // 200)
     if effektive_anzahl >= 50:
-        rollen['Seherlehrling'] = max(1, effektive_anzahl // 150)
+        rollen["Seherlehrling"] = max(1, effektive_anzahl // 150)
     if effektive_anzahl >= 60:
-        rollen['Tratschweib'] = max(1, effektive_anzahl // 200)
+        rollen["Tratschweib"] = max(1, effektive_anzahl // 200)
     if effektive_anzahl >= 75:
-        rollen['Bärenbändiger'] = max(1, effektive_anzahl // 250)
-    
+        rollen["Bärenbändiger"] = max(1, effektive_anzahl // 250)
+
     # Group knowledge roles for very large games
     if effektive_anzahl >= 80:
         schwestern_paare = max(1, effektive_anzahl // 200)
-        rollen['Zwei Schwestern'] = schwestern_paare * 2
+        rollen["Zwei Schwestern"] = schwestern_paare * 2
     if effektive_anzahl >= 100:
         brueder_gruppen = max(1, effektive_anzahl // 250)
-        rollen['Drei Brüder'] = brueder_gruppen * 3
+        rollen["Drei Brüder"] = brueder_gruppen * 3
     if effektive_anzahl >= 120:
         freimaurer_anzahl = max(2, effektive_anzahl // 150)
-        rollen['Freimaurer'] = freimaurer_anzahl
-    
+        rollen["Freimaurer"] = freimaurer_anzahl
+
     # Defensive/utility roles for massive games
     if effektive_anzahl >= 150:
-        rollen['Kräuterweib'] = max(1, effektive_anzahl // 300)
-        rollen['Zauberer'] = max(1, effektive_anzahl // 350)
+        rollen["Kräuterweib"] = max(1, effektive_anzahl // 300)
+        rollen["Zauberer"] = max(1, effektive_anzahl // 350)
     if effektive_anzahl >= 200:
-        rollen['Hure'] = max(1, effektive_anzahl // 300)
-        rollen['Doppelgänger'] = max(1, effektive_anzahl // 400)
+        rollen["Hure"] = max(1, effektive_anzahl // 300)
+        rollen["Doppelgänger"] = max(1, effektive_anzahl // 400)
     if effektive_anzahl >= 300:
-        rollen['Sandmann'] = max(1, effektive_anzahl // 400)
-        rollen['Buddler'] = max(1, effektive_anzahl // 500)
+        rollen["Sandmann"] = max(1, effektive_anzahl // 400)
+        rollen["Buddler"] = max(1, effektive_anzahl // 500)
     if effektive_anzahl >= 400:
-        rollen['Ergebene Magd'] = max(1, effektive_anzahl // 500)
-        rollen['Demoskopin'] = max(1, effektive_anzahl // 500)
+        rollen["Ergebene Magd"] = max(1, effektive_anzahl // 500)
+        rollen["Demoskopin"] = max(1, effektive_anzahl // 500)
     if effektive_anzahl >= 500:
-        rollen['Putzfrau'] = max(1, effektive_anzahl // 600)
-        rollen['Gaukler'] = max(1, effektive_anzahl // 600)
-    
+        rollen["Putzfrau"] = max(1, effektive_anzahl // 600)
+        rollen["Gaukler"] = max(1, effektive_anzahl // 600)
+
     # Aggressive village roles for balance in huge games
     if effektive_anzahl >= 100:
-        rollen['Kamikaze'] = max(1, effektive_anzahl // 300)
+        rollen["Kamikaze"] = max(1, effektive_anzahl // 300)
     if effektive_anzahl >= 200:
-        rollen['Flammenmann'] = max(1, effektive_anzahl // 500)
+        rollen["Flammenmann"] = max(1, effektive_anzahl // 500)
     if effektive_anzahl >= 400:
-        rollen['Inquisitor'] = max(1, effektive_anzahl // 600)
-    
+        rollen["Inquisitor"] = max(1, effektive_anzahl // 600)
+
     # ========================================================================
     # SOLO/NEUTRAL ROLES (Sparsely added - max ~3-5% of players)
     # ========================================================================
     if effektive_anzahl >= 15:
-        rollen['Dorfdepp'] = max(1, effektive_anzahl // 200)
+        rollen["Dorfdepp"] = max(1, effektive_anzahl // 200)
     if effektive_anzahl >= 50:
-        rollen['Flötenspieler'] = max(1, effektive_anzahl // 250)
+        rollen["Flötenspieler"] = max(1, effektive_anzahl // 250)
     if effektive_anzahl >= 100:
-        rollen['Selbstmörder'] = max(1, effektive_anzahl // 300)
+        rollen["Selbstmörder"] = max(1, effektive_anzahl // 300)
     if effektive_anzahl >= 150:
-        rollen['Henker'] = max(1, effektive_anzahl // 400)
+        rollen["Henker"] = max(1, effektive_anzahl // 400)
     if effektive_anzahl >= 300:
-        rollen['Gerber'] = max(1, effektive_anzahl // 500)
+        rollen["Gerber"] = max(1, effektive_anzahl // 500)
     if effektive_anzahl >= 400:
-        rollen['Pyromane'] = max(1, effektive_anzahl // 600)
+        rollen["Pyromane"] = max(1, effektive_anzahl // 600)
     if effektive_anzahl >= 500:
-        rollen['Engel'] = max(1, effektive_anzahl // 700)
-    
+        rollen["Engel"] = max(1, effektive_anzahl // 700)
+
     # ========================================================================
     # OTHER TEAMS (Vampires, Zombies - added in very large games)
     # ========================================================================
     if effektive_anzahl >= 200:
-        rollen['Vampir'] = max(1, effektive_anzahl // 300)
+        rollen["Vampir"] = max(1, effektive_anzahl // 300)
     if effektive_anzahl >= 400:
-        rollen['Zombie'] = max(1, effektive_anzahl // 500)
-    
+        rollen["Zombie"] = max(1, effektive_anzahl // 500)
+
     # ========================================================================
     # EVIL SUPPORT ROLES (to help werewolf team in large games)
     # ========================================================================
     if effektive_anzahl >= 75:
-        rollen['Giftmischerin'] = max(1, effektive_anzahl // 250)
+        rollen["Giftmischerin"] = max(1, effektive_anzahl // 250)
     if effektive_anzahl >= 150:
-        rollen['Hexenmeister'] = max(1, effektive_anzahl // 400)
+        rollen["Hexenmeister"] = max(1, effektive_anzahl // 400)
     if effektive_anzahl >= 300:
-        rollen['Dunkler Priester'] = max(1, effektive_anzahl // 500)
-    
+        rollen["Dunkler Priester"] = max(1, effektive_anzahl // 500)
+
     # ========================================================================
     # DORFBEWOHNER (Fill remaining slots)
     # ========================================================================
-    total_special_roles = sum(v for k, v in rollen.items() if k != 'Erzaehler')
+    total_special_roles = sum(v for k, v in rollen.items() if k != "Erzaehler")
     dorfbewohner_anzahl = effektive_anzahl - total_special_roles
-    
+
     if dorfbewohner_anzahl > 0:
-        rollen['Dorfbewohner'] = dorfbewohner_anzahl
+        rollen["Dorfbewohner"] = dorfbewohner_anzahl
     elif dorfbewohner_anzahl < 0:
         # Too many special roles - reduce werewolves to compensate
         ueberschuss = abs(dorfbewohner_anzahl)
-        print(f"Adjusting roles: reducing Werwolf from {rollen.get('Werwolf', 0)} by {ueberschuss} to fit player count.")
-        if rollen.get('Werwolf', 0) > ueberschuss:
-            rollen['Werwolf'] -= ueberschuss
+        print(
+            f"Adjusting roles: reducing Werwolf from {rollen.get('Werwolf', 0)} by {ueberschuss} to fit player count."
+        )
+        if rollen.get("Werwolf", 0) > ueberschuss:
+            rollen["Werwolf"] -= ueberschuss
         else:
             # Recalculate - this shouldn't happen with proper ratios
             print("Recalculating roles due to excess special roles...")
-            rollen['Dorfbewohner'] = 1
-    
+            rollen["Dorfbewohner"] = 1
+
     return rollen
 
 
 def verteile_rollen(raum: Raum) -> dict:
     """
     Verteilt die Rollen an alle Spieler im Raum.
-    
+
     Args:
         raum: Der Spielraum
-        
+
     Returns:
         Dictionary mit Spieler-ID zu Rolle Mapping
     """
     spieler = Spieler.query.filter_by(raum_id=raum.id, ist_erzaehler=False).all()
     spieler_anzahl = len(spieler)
-    
+
     erzaehler = Spieler.query.filter_by(raum_id=raum.id, ist_erzaehler=True).first()
-    
+
     rollen_verteilung = berechne_rollen(
-        spieler_anzahl + (1 if erzaehler else 0),
-        mit_erzaehler=bool(erzaehler)
+        spieler_anzahl + (1 if erzaehler else 0), mit_erzaehler=bool(erzaehler)
     )
-    
+
     # Erstelle Liste aller zu verteilenden Rollen
     rollen_liste = []
     for rolle, anzahl in rollen_verteilung.items():
-        if rolle != 'Erzaehler':
+        if rolle != "Erzaehler":
             rollen_liste.extend([rolle] * anzahl)
-    
+
     # Mische die Rollen
     random.shuffle(rollen_liste)
     random.shuffle(spieler)
-    
+
     # Weise Rollen zu
     ergebnis = {}
     for i, spieler_obj in enumerate(spieler):
         if i < len(rollen_liste):
             spieler_obj.rolle = rollen_liste[i]
             ergebnis[spieler_obj.id] = rollen_liste[i]
-    
+
     # Erzaehler bekommt spezielle Rolle
     if erzaehler:
-        erzaehler.rolle = 'Erzaehler'
-        ergebnis[erzaehler.id] = 'Erzaehler'
-    
+        erzaehler.rolle = "Erzaehler"
+        ergebnis[erzaehler.id] = "Erzaehler"
+
     db.session.commit()
     return ergebnis
 
@@ -247,36 +249,36 @@ def verteile_rollen(raum: Raum) -> dict:
 def starte_spiel(raum: Raum) -> bool:
     """
     Startet das Spiel im Raum.
-    
+
     Args:
         raum: Der Spielraum
-        
+
     Returns:
         True wenn erfolgreich gestartet
     """
     spieler = Spieler.query.filter_by(raum_id=raum.id).all()
-    
+
     if len(spieler) < 5:
         return False
-    
+
     verteile_rollen(raum)
-    
+
     raum.spiel_gestartet = True
-    raum.aktuelle_phase = 'rollen_verteilt'
+    raum.aktuelle_phase = "rollen_verteilt"
     raum.runde = 1
-    
+
     # Reset Spieler Status
     for s in spieler:
         s.ist_am_leben = True
-        s.status = 'aktiv'
+        s.status = "aktiv"
         s.hexe_heiltrank = True
         s.hexe_gifttrank = True
         s.jaeger_schuss = True
         s.armor_verliebt = True
         s.verliebt_mit_id = None
-    
+
     log_eintrag(raum.id, "Das Spiel hat begonnen! Die Rollen wurden verteilt.")
-    
+
     db.session.commit()
     return True
 
@@ -284,15 +286,18 @@ def starte_spiel(raum: Raum) -> bool:
 def hat_spieler_mit_rolle(raum: Raum, rolle: str) -> bool:
     """
     Prueft ob es einen lebenden Spieler mit der gegebenen Rolle gibt.
-    
+
     Args:
         raum: Der Spielraum
         rolle: Die zu prüfende Rolle
-        
+
     Returns:
         True wenn Rolle existiert, False sonst
     """
-    return Spieler.query.filter_by(raum_id=raum.id, rolle=rolle, ist_am_leben=True).first() is not None
+    return (
+        Spieler.query.filter_by(raum_id=raum.id, rolle=rolle, ist_am_leben=True).first()
+        is not None
+    )
 
 
 def phasennamen_zu_rollen_mapping() -> dict:
@@ -307,15 +312,17 @@ def phasennamen_zu_rollen_mapping() -> dict:
     mapping = RoleRegistry.get_phase_role_mapping()
 
     # Tag-/Spezial-Phasen, die nicht über nacht_aktiv erfasst werden
-    mapping.update({
-        'baerenbaendiger_brummen': 'Bärenbändiger',
-        'demoskopin_info': 'Demoskopin',
-        'prinz_enthuellung': 'Prinz',
-        'jaeger_phase': 'Jäger',
-        'kamikaze_phase': 'Kamikaze',
-        'hahn_enthuellung': 'Hahn',
-        'putzfrau_info': 'Putzfrau',
-    })
+    mapping.update(
+        {
+            "baerenbaendiger_brummen": "Bärenbändiger",
+            "demoskopin_info": "Demoskopin",
+            "prinz_enthuellung": "Prinz",
+            "jaeger_phase": "Jäger",
+            "kamikaze_phase": "Kamikaze",
+            "hahn_enthuellung": "Hahn",
+            "putzfrau_info": "Putzfrau",
+        }
+    )
 
     return mapping
 
@@ -323,48 +330,48 @@ def phasennamen_zu_rollen_mapping() -> dict:
 def naechste_phase(raum: Raum) -> str:
     """
     Wechselt zur naechsten Spielphase.
-    
+
     Args:
         raum: Der Spielraum
-        
+
     Returns:
         Name der neuen Phase
     """
     aktuelle_idx = PHASEN.index(raum.aktuelle_phase)
     phase_mapping = phasennamen_zu_rollen_mapping()
-    
+
     # Spezielle Phasen-Logik
-    if raum.aktuelle_phase == 'armor_phase':
+    if raum.aktuelle_phase == "armor_phase":
         # Armor nur in Runde 1
         if raum.runde > 1:
-            naechste_idx = PHASEN.index('seherin_phase')
+            naechste_idx = PHASEN.index("seherin_phase")
         else:
             naechste_idx = aktuelle_idx + 1
-    elif raum.aktuelle_phase == 'verliebte_info':
+    elif raum.aktuelle_phase == "verliebte_info":
         if raum.runde > 1:
-            naechste_idx = PHASEN.index('seherin_phase')
+            naechste_idx = PHASEN.index("seherin_phase")
         else:
             naechste_idx = aktuelle_idx + 1
-    elif raum.aktuelle_phase == 'tag_ende':
+    elif raum.aktuelle_phase == "tag_ende":
         raum.runde += 1
-        naechste_idx = PHASEN.index('nacht_start')
-    elif raum.aktuelle_phase == 'spiel_ende':
+        naechste_idx = PHASEN.index("nacht_start")
+    elif raum.aktuelle_phase == "spiel_ende":
         naechste_idx = aktuelle_idx  # Bleibt bei spiel_ende
     else:
         naechste_idx = aktuelle_idx + 1
-    
+
     # Pruefe ob die naechste Phase eine erforderliche Rolle hat
     max_iterations = len(PHASEN)
     iterations = 0
     while iterations < max_iterations:
         if naechste_idx >= len(PHASEN):
-            naechste_idx = PHASEN.index('nacht_start')
+            naechste_idx = PHASEN.index("nacht_start")
             raum.runde += 1
             iterations += 1
             continue
-        
+
         naechste_phase_name = PHASEN[naechste_idx]
-        
+
         # Prüfe ob diese Phase eine erforderliche Rolle benötigt
         if naechste_phase_name in phase_mapping:
             erforderliche_rolle = phase_mapping[naechste_phase_name]
@@ -373,17 +380,17 @@ def naechste_phase(raum: Raum) -> str:
                 naechste_idx += 1
                 iterations += 1
                 continue
-        
+
         # Phase ist gültig
         break
-    
+
     if naechste_idx >= len(PHASEN):
-        naechste_idx = PHASEN.index('nacht_start')
+        naechste_idx = PHASEN.index("nacht_start")
         raum.runde += 1
-        
+
     raum.aktuelle_phase = PHASEN[naechste_idx]
     db.session.commit()
-    
+
     return raum.aktuelle_phase
 
 
@@ -394,40 +401,41 @@ def ist_werwolf_rolle(rolle: str) -> bool:
     """
     from roles import RoleRegistry
     from roles.enums import Team
-    
+
     rolle_obj = RoleRegistry.get(rolle)
     if rolle_obj:
         return rolle_obj.info.team == Team.WERWOLF
-    
+
     rolle_info = ROLLEN.get(rolle, {})
     if rolle_info:
-        return rolle_info.get('team') == 'werwolf'
-    
-    return 'werwolf' in (rolle or '').lower()
+        return rolle_info.get("team") == "werwolf"
+
+    return "werwolf" in (rolle or "").lower()
 
 
 def pruefe_spielende(raum: Raum) -> dict | None:
     """
     Prueft ob das Spiel zu Ende ist.
-    
+
     Args:
         raum: Der Spielraum
-        
+
     Returns:
         Dictionary mit Gewinner-Info oder None wenn Spiel weitergeht
     """
-    lebende = Spieler.query.filter_by(raum_id=raum.id, ist_am_leben=True, ist_erzaehler=False).all()
-    
+    lebende = Spieler.query.filter_by(
+        raum_id=raum.id, ist_am_leben=True, ist_erzaehler=False
+    ).all()
+
     # Beruecksichtige alle Werwolf-Varianten
     werwoelfe = [s for s in lebende if ist_werwolf_rolle(s.rolle)]
     dorfbewohner = [s for s in lebende if not ist_werwolf_rolle(s.rolle)]
-    
+
     # Verliebten-Check
     verliebte = Spieler.query.filter(
-        Spieler.raum_id == raum.id,
-        Spieler.verliebt_mit_id.isnot(None)
+        Spieler.raum_id == raum.id, Spieler.verliebt_mit_id.isnot(None)
     ).all()
-    
+
     if len(verliebte) == 2 and all(v.ist_am_leben for v in verliebte):
         # Pruefen ob nur noch die Verliebten leben
         if len(lebende) == 2:
@@ -436,68 +444,67 @@ def pruefe_spielende(raum: Raum) -> dict | None:
             hat_wolf = any(ist_werwolf_rolle(r) for r in rollen)
             if hat_wolf and len(rollen) > 1:
                 return {
-                    'gewinner': 'verliebte',
-                    'nachricht': 'Die Verliebten haben gewonnen! Ihre Liebe hat alle ueberwunden.',
-                    'spieler': [v.name for v in verliebte]
+                    "gewinner": "verliebte",
+                    "nachricht": "Die Verliebten haben gewonnen! Ihre Liebe hat alle ueberwunden.",
+                    "spieler": [v.name for v in verliebte],
                 }
-    
+
     # Keine Werwoelfe mehr
     if len(werwoelfe) == 0:
         return {
-            'gewinner': 'dorf',
-            'nachricht': 'Das Dorf hat gewonnen! Alle Werwoelfe wurden eliminiert.',
-            'spieler': [s.name for s in dorfbewohner]
+            "gewinner": "dorf",
+            "nachricht": "Das Dorf hat gewonnen! Alle Werwoelfe wurden eliminiert.",
+            "spieler": [s.name for s in dorfbewohner],
         }
-    
+
     # Werwoelfe in Ueberzahl oder Gleichstand
     if len(werwoelfe) >= len(dorfbewohner):
         return {
-            'gewinner': 'werwolf',
-            'nachricht': 'Die Werwoelfe haben gewonnen! Das Dorf ist gefallen.',
-            'spieler': [s.name for s in werwoelfe]
+            "gewinner": "werwolf",
+            "nachricht": "Die Werwoelfe haben gewonnen! Das Dorf ist gefallen.",
+            "spieler": [s.name for s in werwoelfe],
         }
-    
+
     return None
 
 
-def toete_spieler(spieler: Spieler, todesart: str = 'unbekannt') -> dict:
+def toete_spieler(spieler: Spieler, todesart: str = "unbekannt") -> dict:
     """
     Toetet einen Spieler.
-    
+
     Args:
         spieler: Der zu toetende Spieler
         todesart: Art des Todes (werwolf, abstimmung, hexe, jaeger)
-        
+
     Returns:
         Dictionary mit Todes-Informationen
     """
     spieler.ist_am_leben = False
-    spieler.status = 'tot'
-    
+    spieler.status = "tot"
+
     ergebnis = {
-        'spieler_id': spieler.id,
-        'spieler_name': spieler.name,
-        'rolle': spieler.rolle,
-        'todesart': todesart,
-        'folge_aktionen': []
+        "spieler_id": spieler.id,
+        "spieler_name": spieler.name,
+        "rolle": spieler.rolle,
+        "todesart": todesart,
+        "folge_aktionen": [],
     }
-    
+
     # Jaeger stirbt - kann noch schiessen
-    if spieler.rolle == 'Jäger' and spieler.jaeger_schuss:
-        ergebnis['folge_aktionen'].append('jaeger_schuss')
-    
+    if spieler.rolle == "Jäger" and spieler.jaeger_schuss:
+        ergebnis["folge_aktionen"].append("jaeger_schuss")
+
     # Verliebter stirbt - Partner stirbt auch
     if spieler.verliebt_mit_id:
         partner = Spieler.query.get(spieler.verliebt_mit_id)
         if partner and partner.ist_am_leben:
-            ergebnis['folge_aktionen'].append('partner_stirbt')
-            ergebnis['partner'] = partner.name
-    
+            ergebnis["folge_aktionen"].append("partner_stirbt")
+            ergebnis["partner"] = partner.name
+
     log_eintrag(
-        spieler.raum_id,
-        f"{spieler.name} ist gestorben. (Todesart: {todesart})"
+        spieler.raum_id, f"{spieler.name} ist gestorben. (Todesart: {todesart})"
     )
-    
+
     db.session.commit()
     return ergebnis
 
@@ -505,119 +512,121 @@ def toete_spieler(spieler: Spieler, todesart: str = 'unbekannt') -> dict:
 def werwolf_abstimmung(raum: Raum) -> dict | None:
     """
     Wertet die Werwolf-Abstimmung aus.
-    
+
     Args:
         raum: Der Spielraum
-        
+
     Returns:
         Ergebnis der Abstimmung oder None
     """
     aktionen = SpielAktion.query.filter_by(
         raum_id=raum.id,
         runde=raum.runde,
-        phase='werwolf_phase',
-        aktion_typ='werwolf_wahl'
+        phase="werwolf_phase",
+        aktion_typ="werwolf_wahl",
     ).all()
-    
+
     if not aktionen:
         return None
-    
+
     # Zaehle Stimmen
     stimmen = {}
     for aktion in aktionen:
         ziel_id = aktion.ziel_spieler_id
         stimmen[ziel_id] = stimmen.get(ziel_id, 0) + 1
-    
+
     # Finde Opfer (meiste Stimmen)
     max_stimmen = max(stimmen.values())
     opfer_ids = [sid for sid, count in stimmen.items() if count == max_stimmen]
-    
+
     # Bei Gleichstand: zufaellig waehlen
     opfer_id = random.choice(opfer_ids)
     opfer = Spieler.query.get(opfer_id)
-    
+
     return {
-        'opfer_id': opfer_id,
-        'opfer_name': opfer.name if opfer else 'Unbekannt',
-        'stimmen': max_stimmen
+        "opfer_id": opfer_id,
+        "opfer_name": opfer.name if opfer else "Unbekannt",
+        "stimmen": max_stimmen,
     }
 
 
 def tag_abstimmung(raum: Raum) -> dict | None:
     """
     Wertet die Tag-Abstimmung aus.
-    
+
     Args:
         raum: Der Spielraum
-        
+
     Returns:
         Ergebnis der Abstimmung oder None
     """
     aktionen = SpielAktion.query.filter_by(
-        raum_id=raum.id,
-        runde=raum.runde,
-        phase='abstimmung',
-        aktion_typ='tag_wahl'
+        raum_id=raum.id, runde=raum.runde, phase="abstimmung", aktion_typ="tag_wahl"
     ).all()
-    
+
     if not aktionen:
         return None
-    
+
     # Zaehle Stimmen
     stimmen = {}
     for aktion in aktionen:
         ziel_id = aktion.ziel_spieler_id
         if ziel_id:  # None = Enthaltung
             stimmen[ziel_id] = stimmen.get(ziel_id, 0) + 1
-    
+
     if not stimmen:
-        return {'kein_opfer': True, 'nachricht': 'Niemand wurde gewaehlt.'}
-    
+        return {"kein_opfer": True, "nachricht": "Niemand wurde gewaehlt."}
+
     # Finde Opfer (meiste Stimmen)
     max_stimmen = max(stimmen.values())
     opfer_ids = [sid for sid, count in stimmen.items() if count == max_stimmen]
-    
+
     # Mehrheit erforderlich
-    lebende = Spieler.query.filter_by(raum_id=raum.id, ist_am_leben=True, ist_erzaehler=False).count()
+    lebende = Spieler.query.filter_by(
+        raum_id=raum.id, ist_am_leben=True, ist_erzaehler=False
+    ).count()
     if max_stimmen <= lebende // 2:
-        return {'kein_opfer': True, 'nachricht': 'Keine Mehrheit erreicht.'}
-    
+        return {"kein_opfer": True, "nachricht": "Keine Mehrheit erreicht."}
+
     # Bei Gleichstand: niemand stirbt
     if len(opfer_ids) > 1:
-        return {'kein_opfer': True, 'nachricht': 'Stimmengleichheit - niemand stirbt.'}
-    
+        return {"kein_opfer": True, "nachricht": "Stimmengleichheit - niemand stirbt."}
+
     opfer_id = opfer_ids[0]
     opfer = Spieler.query.get(opfer_id)
-    
+
     return {
-        'opfer_id': opfer_id,
-        'opfer_name': opfer.name if opfer else 'Unbekannt',
-        'opfer_rolle': opfer.rolle if opfer else 'Unbekannt',
-        'stimmen': max_stimmen
+        "opfer_id": opfer_id,
+        "opfer_name": opfer.name if opfer else "Unbekannt",
+        "opfer_rolle": opfer.rolle if opfer else "Unbekannt",
+        "stimmen": max_stimmen,
     }
 
 
-def log_eintrag(raum_id: int, nachricht: str, sichtbar_fuer: str = 'alle'):
+def log_eintrag(raum_id: int, nachricht: str, sichtbar_fuer: str = "alle"):
     """
     Erstellt einen Spiellog-Eintrag.
-    
+
     Args:
         raum_id: ID des Raums
         nachricht: Log-Nachricht
         sichtbar_fuer: Wer kann den Eintrag sehen
     """
     eintrag = SpielLog(
-        raum_id=raum_id,
-        nachricht=nachricht,
-        sichtbar_fuer=sichtbar_fuer
+        raum_id=raum_id, nachricht=nachricht, sichtbar_fuer=sichtbar_fuer
     )
     db.session.add(eintrag)
     db.session.commit()
 
 
-def registriere_aktion(raum_id: int, runde: int, phase: str, 
-                       aktion_typ: str, von_spieler_id: int, 
-                       ziel_spieler_id: int = None):
+def registriere_aktion(
+    raum_id: int,
+    runde: int,
+    phase: str,
+    aktion_typ: str,
+    von_spieler_id: int,
+    ziel_spieler_id: int = None,
+):
     """
     Registriert eine Spielaktion.
     """
@@ -627,7 +636,7 @@ def registriere_aktion(raum_id: int, runde: int, phase: str,
         phase=phase,
         aktion_typ=aktion_typ,
         von_spieler_id=von_spieler_id,
-        ziel_spieler_id=ziel_spieler_id
+        ziel_spieler_id=ziel_spieler_id,
     )
     db.session.add(aktion)
     db.session.commit()
@@ -649,9 +658,7 @@ def hole_spieler_fuer_rolle(raum: Raum, rolle: str) -> list:
     Gibt alle Spieler einer bestimmten Rolle zurueck.
     """
     return Spieler.query.filter_by(
-        raum_id=raum.id, 
-        rolle=rolle,
-        ist_am_leben=True
+        raum_id=raum.id, rolle=rolle, ist_am_leben=True
     ).all()
 
 
@@ -660,10 +667,7 @@ def hat_spieler_gewaehlt(spieler: Spieler, raum: Raum, phase: str) -> bool:
     Prueft ob ein Spieler in der aktuellen Phase bereits gewaehlt hat.
     """
     aktion = SpielAktion.query.filter_by(
-        raum_id=raum.id,
-        runde=raum.runde,
-        phase=phase,
-        von_spieler_id=spieler.id
+        raum_id=raum.id, runde=raum.runde, phase=phase, von_spieler_id=spieler.id
     ).first()
     return aktion is not None
 
@@ -676,9 +680,8 @@ def alle_haben_gewaehlt(raum: Raum, phase: str, rolle: str = None) -> bool:
         spieler = hole_spieler_fuer_rolle(raum, rolle)
     else:
         spieler = hole_lebende_spieler(raum)
-    
+
     for s in spieler:
         if not hat_spieler_gewaehlt(s, raum, phase):
             return False
     return True
-

--- a/models.py
+++ b/models.py
@@ -2,6 +2,7 @@
 Datenbankmodelle für das Webwölfe-Spiel
 Alle Rollen basierend auf: https://werwolf.fandom.com/de/wiki/Werwolf-Rollen-Sammlung
 """
+
 from flask_sqlalchemy import SQLAlchemy
 from datetime import datetime
 import secrets
@@ -11,159 +12,179 @@ db = SQLAlchemy()
 
 class Raum(db.Model):
     """Ein Spielraum/Lobby"""
-    __tablename__ = 'raeume'
-    
+
+    __tablename__ = "raeume"
+
     id = db.Column(db.Integer, primary_key=True)
     code = db.Column(db.String(6), unique=True, nullable=False, index=True)
     name = db.Column(db.String(50), nullable=False)
-    modus = db.Column(db.String(20), nullable=False, default='online')  # 'online' oder 'gruppe'
+    modus = db.Column(
+        db.String(20), nullable=False, default="online"
+    )  # 'online' oder 'gruppe'
     erstellt_am = db.Column(db.DateTime, default=datetime.utcnow)
     spieler_anzahl = db.Column(db.Integer, default=8)
     spiel_gestartet = db.Column(db.Boolean, default=False)
-    aktuelle_phase = db.Column(db.String(30), default='lobby')
+    aktuelle_phase = db.Column(db.String(30), default="lobby")
     runde = db.Column(db.Integer, default=0)
-    erzaehler_id = db.Column(db.Integer, db.ForeignKey('spieler.id'), nullable=True)
-    
+    erzaehler_id = db.Column(db.Integer, db.ForeignKey("spieler.id"), nullable=True)
+
     # Spielende
     spiel_beendet = db.Column(db.Boolean, default=False)
     gewinner = db.Column(db.String(50), nullable=True)
-    
+
     # Rollen-Konfiguration (JSON der aktivierten Rollen)
-    aktive_rollen = db.Column(db.Text, default='{}')
-    
-    spieler = db.relationship('Spieler', backref='raum', lazy=True, foreign_keys='Spieler.raum_id')
-    
+    aktive_rollen = db.Column(db.Text, default="{}")
+
+    spieler = db.relationship(
+        "Spieler", backref="raum", lazy=True, foreign_keys="Spieler.raum_id"
+    )
+
     @staticmethod
     def generiere_code():
         """Generiert einen einzigartigen 6-stelligen Raumcode"""
         while True:
-            code = ''.join(secrets.choice('ABCDEFGHJKLMNPQRSTUVWXYZ23456789') for _ in range(6))
+            code = "".join(
+                secrets.choice("ABCDEFGHJKLMNPQRSTUVWXYZ23456789") for _ in range(6)
+            )
             if not Raum.query.filter_by(code=code).first():
                 return code
 
 
 class Spieler(db.Model):
     """Ein Spieler im Spiel"""
-    __tablename__ = 'spieler'
-    
+
+    __tablename__ = "spieler"
+
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(30), nullable=False)
     session_id = db.Column(db.String(64), unique=True, nullable=False, index=True)
-    raum_id = db.Column(db.Integer, db.ForeignKey('raeume.id'), nullable=True, index=True)
+    raum_id = db.Column(
+        db.Integer, db.ForeignKey("raeume.id"), nullable=True, index=True
+    )
     rolle = db.Column(db.String(30), nullable=True, index=True)
     ist_am_leben = db.Column(db.Boolean, default=True, index=True)
     ist_erzaehler = db.Column(db.Boolean, default=False)
-    status = db.Column(db.String(20), default='wartend')  # wartend, schläft, aktiv, tot
+    status = db.Column(db.String(20), default="wartend")  # wartend, schläft, aktiv, tot
     beigetreten_am = db.Column(db.DateTime, default=datetime.utcnow)
-    
+
     # Composite indexes for common query patterns in large games
     __table_args__ = (
-        db.Index('idx_spieler_raum_leben', 'raum_id', 'ist_am_leben'),
-        db.Index('idx_spieler_raum_rolle', 'raum_id', 'rolle'),
-        db.Index('idx_spieler_raum_erzaehler', 'raum_id', 'ist_erzaehler'),
+        db.Index("idx_spieler_raum_leben", "raum_id", "ist_am_leben"),
+        db.Index("idx_spieler_raum_rolle", "raum_id", "rolle"),
+        db.Index("idx_spieler_raum_erzaehler", "raum_id", "ist_erzaehler"),
     )
-    
+
     # Sitzplatz-System für Nachbar-Mechanik und 3D-Visualisierung
     sitzplatz = db.Column(db.Integer, nullable=True)  # Position im Kreis (0-n)
     # Nachbarn werden dynamisch berechnet basierend auf sitzplatz
-    
+
     # Spezielle Fähigkeiten Status
     hexe_heiltrank = db.Column(db.Boolean, default=True)
     hexe_gifttrank = db.Column(db.Boolean, default=True)
     jaeger_schuss = db.Column(db.Boolean, default=True)
     armor_verliebt = db.Column(db.Boolean, default=True)
-    heiler_geschuetzt = db.Column(db.Integer, nullable=True)  # ID des zuletzt geschützten Spielers
-    
+    heiler_geschuetzt = db.Column(
+        db.Integer, nullable=True
+    )  # ID des zuletzt geschützten Spielers
+
     # Einmalige Fähigkeiten
     urwolf_infektion = db.Column(db.Boolean, default=True)  # Kann noch infizieren
     kamikaze_bombe = db.Column(db.Boolean, default=True)  # Kann sich noch opfern
     jesus_auferstehung = db.Column(db.Boolean, default=True)  # Kann noch auferstehen
     leibwaechter_opfer = db.Column(db.Boolean, default=True)  # Kann sich noch opfern
-    
+
     # Spezielle Rollen-Flags
     ist_infiziert = db.Column(db.Boolean, default=False)  # Urwolf-Infektion
     ist_verzaubert = db.Column(db.Boolean, default=False)  # Flötenspieler-Verzauberung
     ist_verflucht = db.Column(db.Boolean, default=False)  # Fluch (wird zum Werwolf)
-    ist_beschuetzt = db.Column(db.Boolean, default=False)  # Heiler-Schutz für diese Nacht
+    ist_beschuetzt = db.Column(
+        db.Boolean, default=False
+    )  # Heiler-Schutz für diese Nacht
     ist_stumm = db.Column(db.Boolean, default=False)  # Kräuterweib-Stummheit
     ist_vergiftet = db.Column(db.Integer, default=0)  # Giftmischerin - Tage bis Tod
     rabe_markiert = db.Column(db.Boolean, default=False)  # Rabe-Markierung
     alter_mann_leben = db.Column(db.Integer, default=2)  # Anzahl Leben
-    
+
     # Verliebt mit
-    verliebt_mit_id = db.Column(db.Integer, db.ForeignKey('spieler.id'), nullable=True)
-    
+    verliebt_mit_id = db.Column(db.Integer, db.ForeignKey("spieler.id"), nullable=True)
+
     # Vorbild (für Wildes Kind)
-    vorbild_id = db.Column(db.Integer, db.ForeignKey('spieler.id'), nullable=True)
-    
+    vorbild_id = db.Column(db.Integer, db.ForeignKey("spieler.id"), nullable=True)
+
     # Doppelgänger-Ziel
-    doppelgaenger_ziel_id = db.Column(db.Integer, db.ForeignKey('spieler.id'), nullable=True)
-    
+    doppelgaenger_ziel_id = db.Column(
+        db.Integer, db.ForeignKey("spieler.id"), nullable=True
+    )
+
     # Henker-Ziel
-    henker_ziel_id = db.Column(db.Integer, db.ForeignKey('spieler.id'), nullable=True)
-    
+    henker_ziel_id = db.Column(db.Integer, db.ForeignKey("spieler.id"), nullable=True)
+
     # Herrchen (für Hund)
-    herrchen_id = db.Column(db.Integer, db.ForeignKey('spieler.id'), nullable=True)
-    
+    herrchen_id = db.Column(db.Integer, db.ForeignKey("spieler.id"), nullable=True)
+
     # Hund hat sein Herrchen bereits gewählt
     hund_herrchen_gewaehlt = db.Column(db.Boolean, default=False)
-    
+
     @staticmethod
     def generiere_session():
         """Generiert eine einzigartige Session-ID"""
         return secrets.token_hex(32)
-    
+
     def hole_nachbar_links(self):
         """Gibt den linken Nachbarn zurück (im Uhrzeigersinn)"""
         if self.sitzplatz is None or not self.raum_id:
             return None
-        lebende_spieler = Spieler.query.filter_by(
-            raum_id=self.raum_id, 
-            ist_am_leben=True,
-            ist_erzaehler=False
-        ).order_by(Spieler.sitzplatz).all()
+        lebende_spieler = (
+            Spieler.query.filter_by(
+                raum_id=self.raum_id, ist_am_leben=True, ist_erzaehler=False
+            )
+            .order_by(Spieler.sitzplatz)
+            .all()
+        )
         if len(lebende_spieler) < 2:
             return None
-        
+
         # Finde Position in der Liste der lebenden Spieler
         eigene_position = None
         for i, s in enumerate(lebende_spieler):
             if s.id == self.id:
                 eigene_position = i
                 break
-        
+
         if eigene_position is None:
             return None
-        
+
         # Linker Nachbar (einer weniger, mit Wrap-Around)
         nachbar_pos = (eigene_position - 1) % len(lebende_spieler)
         return lebende_spieler[nachbar_pos]
-    
+
     def hole_nachbar_rechts(self):
         """Gibt den rechten Nachbarn zurück (gegen Uhrzeigersinn)"""
         if self.sitzplatz is None or not self.raum_id:
             return None
-        lebende_spieler = Spieler.query.filter_by(
-            raum_id=self.raum_id, 
-            ist_am_leben=True,
-            ist_erzaehler=False
-        ).order_by(Spieler.sitzplatz).all()
+        lebende_spieler = (
+            Spieler.query.filter_by(
+                raum_id=self.raum_id, ist_am_leben=True, ist_erzaehler=False
+            )
+            .order_by(Spieler.sitzplatz)
+            .all()
+        )
         if len(lebende_spieler) < 2:
             return None
-        
+
         eigene_position = None
         for i, s in enumerate(lebende_spieler):
             if s.id == self.id:
                 eigene_position = i
                 break
-        
+
         if eigene_position is None:
             return None
-        
+
         # Rechter Nachbar (einer mehr, mit Wrap-Around)
         nachbar_pos = (eigene_position + 1) % len(lebende_spieler)
         return lebende_spieler[nachbar_pos]
-    
+
     def hole_beide_nachbarn(self):
         """Gibt beide Nachbarn als Liste zurück"""
         nachbarn = []
@@ -178,52 +199,59 @@ class Spieler(db.Model):
 
 class SpielAktion(db.Model):
     """Aktionen während des Spiels (Abstimmungen, Tötungen, etc.)"""
-    __tablename__ = 'aktionen'
-    
+
+    __tablename__ = "aktionen"
+
     id = db.Column(db.Integer, primary_key=True)
-    raum_id = db.Column(db.Integer, db.ForeignKey('raeume.id'), nullable=False)
+    raum_id = db.Column(db.Integer, db.ForeignKey("raeume.id"), nullable=False)
     runde = db.Column(db.Integer, nullable=False)
     phase = db.Column(db.String(30), nullable=False)
     aktion_typ = db.Column(db.String(30), nullable=False)
-    von_spieler_id = db.Column(db.Integer, db.ForeignKey('spieler.id'), nullable=False)
-    ziel_spieler_id = db.Column(db.Integer, db.ForeignKey('spieler.id'), nullable=True)
+    von_spieler_id = db.Column(db.Integer, db.ForeignKey("spieler.id"), nullable=False)
+    ziel_spieler_id = db.Column(db.Integer, db.ForeignKey("spieler.id"), nullable=True)
     zusatz_daten = db.Column(db.Text, nullable=True)  # JSON für komplexe Aktionen
     zeitpunkt = db.Column(db.DateTime, default=datetime.utcnow)
-    
-    von_spieler = db.relationship('Spieler', foreign_keys=[von_spieler_id])
-    ziel_spieler = db.relationship('Spieler', foreign_keys=[ziel_spieler_id])
+
+    von_spieler = db.relationship("Spieler", foreign_keys=[von_spieler_id])
+    ziel_spieler = db.relationship("Spieler", foreign_keys=[ziel_spieler_id])
 
 
 class SpielLog(db.Model):
     """Spielverlauf-Protokoll"""
-    __tablename__ = 'spiellog'
-    
+
+    __tablename__ = "spiellog"
+
     id = db.Column(db.Integer, primary_key=True)
-    raum_id = db.Column(db.Integer, db.ForeignKey('raeume.id'), nullable=False)
+    raum_id = db.Column(db.Integer, db.ForeignKey("raeume.id"), nullable=False)
     nachricht = db.Column(db.Text, nullable=False)
     zeitpunkt = db.Column(db.DateTime, default=datetime.utcnow)
-    sichtbar_fuer = db.Column(db.String(100), default='alle')  # alle, erzähler, werwolf, spieler_id
+    sichtbar_fuer = db.Column(
+        db.String(100), default="alle"
+    )  # alle, erzähler, werwolf, spieler_id
 
 
 class ErzaehlerEvent(db.Model):
     """Tracker für einmalige Erzähler-Events (verhindert Wiederholung)"""
-    __tablename__ = 'erzaehler_events'
-    
+
+    __tablename__ = "erzaehler_events"
+
     id = db.Column(db.Integer, primary_key=True)
-    raum_id = db.Column(db.Integer, db.ForeignKey('raeume.id'), nullable=False)
-    event_typ = db.Column(db.String(50), nullable=False)  # z.B. 'amor_verliebte', 'wildes_kind_vorbild'
+    raum_id = db.Column(db.Integer, db.ForeignKey("raeume.id"), nullable=False)
+    event_typ = db.Column(
+        db.String(50), nullable=False
+    )  # z.B. 'amor_verliebte', 'wildes_kind_vorbild'
     runde = db.Column(db.Integer, nullable=True)  # In welcher Runde Event passierte
     ziel_spieler_ids = db.Column(db.String(100), nullable=True)  # Komma-getrennte IDs
     gespielt_am = db.Column(db.DateTime, default=datetime.utcnow)
-    
+
     @staticmethod
     def event_bereits_gespielt(raum_id, event_typ):
         """Prüft ob ein Event bereits gespielt wurde"""
-        return ErzaehlerEvent.query.filter_by(
-            raum_id=raum_id, 
-            event_typ=event_typ
-        ).first() is not None
-    
+        return (
+            ErzaehlerEvent.query.filter_by(raum_id=raum_id, event_typ=event_typ).first()
+            is not None
+        )
+
     @staticmethod
     def registriere_event(raum_id, event_typ, runde=None, ziel_spieler_ids=None):
         """Registriert ein gespieltes Event"""
@@ -231,7 +259,9 @@ class ErzaehlerEvent(db.Model):
             raum_id=raum_id,
             event_typ=event_typ,
             runde=runde,
-            ziel_spieler_ids=','.join(map(str, ziel_spieler_ids)) if ziel_spieler_ids else None
+            ziel_spieler_ids=(
+                ",".join(map(str, ziel_spieler_ids)) if ziel_spieler_ids else None
+            ),
         )
         db.session.add(event)
         db.session.commit()
@@ -240,17 +270,20 @@ class ErzaehlerEvent(db.Model):
 
 class SpielerPosition(db.Model):
     """3D-Position eines Spielers im Dorf (für Visualisierung)"""
-    __tablename__ = 'spieler_positionen'
-    
+
+    __tablename__ = "spieler_positionen"
+
     id = db.Column(db.Integer, primary_key=True)
-    spieler_id = db.Column(db.Integer, db.ForeignKey('spieler.id'), nullable=False, unique=True)
+    spieler_id = db.Column(
+        db.Integer, db.ForeignKey("spieler.id"), nullable=False, unique=True
+    )
     # Position im 3D-Raum (Einheitskreis um Lagerfeuer)
     winkel = db.Column(db.Float, nullable=False)  # Winkel in Grad (0-360)
     radius = db.Column(db.Float, default=5.0)  # Abstand vom Zentrum
     # Visuelle Eigenschaften
-    avatar_typ = db.Column(db.String(20), default='default')  # Charakter-Modell
-    
-    spieler = db.relationship('Spieler', backref='position_3d')
+    avatar_typ = db.Column(db.String(20), default="default")  # Charakter-Modell
+
+    spieler = db.relationship("Spieler", backref="position_3d")
 
 
 # ============================================================================
@@ -259,194 +292,193 @@ class SpielerPosition(db.Model):
 
 # PHASE-BASIERTE TEXTE (werden jede Runde wiederholt)
 ERZAEHLER_PHASEN = {
-    'nacht_start': {
-        'text': 'Das Dorf schläft ein. Alle Spieler schließen die Augen.',
-        'anweisung': 'Warte bis alle Spieler die Augen geschlossen haben.',
-        'wiederholbar': True,
+    "nacht_start": {
+        "text": "Das Dorf schläft ein. Alle Spieler schließen die Augen.",
+        "anweisung": "Warte bis alle Spieler die Augen geschlossen haben.",
+        "wiederholbar": True,
     },
-    'werwolf_phase': {
-        'text': 'Die Werwölfe erwachen. Sie erkennen sich und wählen gemeinsam ein Opfer.',
-        'anweisung': 'Die Werwölfe öffnen die Augen, schauen sich an und zeigen stumm auf ihr Opfer. Bestätige das Opfer mit einem Nicken.',
-        'wiederholbar': True,
+    "werwolf_phase": {
+        "text": "Die Werwölfe erwachen. Sie erkennen sich und wählen gemeinsam ein Opfer.",
+        "anweisung": "Die Werwölfe öffnen die Augen, schauen sich an und zeigen stumm auf ihr Opfer. Bestätige das Opfer mit einem Nicken.",
+        "wiederholbar": True,
     },
-    'seherin_phase': {
-        'text': 'Die Seherin erwacht und wählt einen Spieler, dessen Identität sie erfahren möchte.',
-        'anweisung': 'Die Seherin öffnet die Augen und zeigt auf einen Spieler. Zeige ihr mit Daumen hoch (Dorf) oder runter (Wolf) die Zugehörigkeit.',
-        'wiederholbar': True,
+    "seherin_phase": {
+        "text": "Die Seherin erwacht und wählt einen Spieler, dessen Identität sie erfahren möchte.",
+        "anweisung": "Die Seherin öffnet die Augen und zeigt auf einen Spieler. Zeige ihr mit Daumen hoch (Dorf) oder runter (Wolf) die Zugehörigkeit.",
+        "wiederholbar": True,
     },
-    'hexe_phase': {
-        'text': 'Die Hexe erwacht. Sie erfährt das Opfer der Werwölfe.',
-        'anweisung': 'Die Hexe öffnet die Augen. Zeige auf das Werwolf-Opfer. Frage mit Gesten: Heiltrank? Gifttrank?',
-        'wiederholbar': True,
+    "hexe_phase": {
+        "text": "Die Hexe erwacht. Sie erfährt das Opfer der Werwölfe.",
+        "anweisung": "Die Hexe öffnet die Augen. Zeige auf das Werwolf-Opfer. Frage mit Gesten: Heiltrank? Gifttrank?",
+        "wiederholbar": True,
     },
-    'heiler_phase': {
-        'text': 'Der Heiler erwacht und wählt einen Spieler, den er in dieser Nacht beschützen möchte.',
-        'anweisung': 'Der Heiler öffnet die Augen und zeigt auf den zu schützenden Spieler. Bestätige mit einem Nicken.',
-        'wiederholbar': True,
+    "heiler_phase": {
+        "text": "Der Heiler erwacht und wählt einen Spieler, den er in dieser Nacht beschützen möchte.",
+        "anweisung": "Der Heiler öffnet die Augen und zeigt auf den zu schützenden Spieler. Bestätige mit einem Nicken.",
+        "wiederholbar": True,
     },
-    'tag_start': {
-        'text': 'Die Sonne geht auf. Das Dorf erwacht.',
-        'anweisung': 'Alle öffnen die Augen. Verkünde die Opfer der Nacht.',
-        'wiederholbar': True,
+    "tag_start": {
+        "text": "Die Sonne geht auf. Das Dorf erwacht.",
+        "anweisung": "Alle öffnen die Augen. Verkünde die Opfer der Nacht.",
+        "wiederholbar": True,
     },
-    'diskussion': {
-        'text': 'Die Dorfbewohner diskutieren. Wer könnte ein Werwolf sein?',
-        'anweisung': 'Die Spieler diskutieren frei. Als Erzähler greifst du nur bei Regelfragen ein.',
-        'wiederholbar': True,
+    "diskussion": {
+        "text": "Die Dorfbewohner diskutieren. Wer könnte ein Werwolf sein?",
+        "anweisung": "Die Spieler diskutieren frei. Als Erzähler greifst du nur bei Regelfragen ein.",
+        "wiederholbar": True,
     },
-    'abstimmung': {
-        'text': 'Die Abstimmung beginnt. Jeder Spieler zeigt auf den Verdächtigen.',
-        'anweisung': 'Bei 3 zeigen alle gleichzeitig. Zähle die Stimmen.',
-        'wiederholbar': True,
+    "abstimmung": {
+        "text": "Die Abstimmung beginnt. Jeder Spieler zeigt auf den Verdächtigen.",
+        "anweisung": "Bei 3 zeigen alle gleichzeitig. Zähle die Stimmen.",
+        "wiederholbar": True,
     },
 }
 
 # EVENT-BASIERTE TEXTE (nur einmal pro Spiel!)
 ERZAEHLER_EVENTS = {
     # === ERSTE NACHT EVENTS (nur in Runde 1) ===
-    'erste_nacht_intro': {
-        'text': 'Willkommen in Düsterwald! Die erste Nacht bricht herein. In diesem Dorf verbergen sich Werwölfe unter den friedlichen Bewohnern.',
-        'anweisung': 'Lies diesen Text atmosphärisch vor. Dann beginne mit den Rollen.',
-        'bedingung': {'runde': 1, 'phase': 'nacht'},
-        'einmalig': True,
+    "erste_nacht_intro": {
+        "text": "Willkommen in Düsterwald! Die erste Nacht bricht herein. In diesem Dorf verbergen sich Werwölfe unter den friedlichen Bewohnern.",
+        "anweisung": "Lies diesen Text atmosphärisch vor. Dann beginne mit den Rollen.",
+        "bedingung": {"runde": 1, "phase": "nacht"},
+        "einmalig": True,
     },
-    'armor_verliebte': {
-        'text': 'Amor erwacht in dieser ersten Nacht. Er wählt zwei Spieler, die sich unsterblich verlieben werden. Ihre Schicksale sind nun für immer verbunden.',
-        'anweisung': 'Amor öffnet die Augen und zeigt auf zwei Spieler. Berühre diese leicht an der Schulter.',
-        'bedingung': {'runde': 1, 'rolle_aktiv': 'Amor'},
-        'einmalig': True,
+    "armor_verliebte": {
+        "text": "Amor erwacht in dieser ersten Nacht. Er wählt zwei Spieler, die sich unsterblich verlieben werden. Ihre Schicksale sind nun für immer verbunden.",
+        "anweisung": "Amor öffnet die Augen und zeigt auf zwei Spieler. Berühre diese leicht an der Schulter.",
+        "bedingung": {"runde": 1, "rolle_aktiv": "Amor"},
+        "einmalig": True,
     },
-    'verliebte_erfahren': {
-        'text': 'Die Verliebten erwachen kurz und erkennen einander. Sie dürfen die Augen öffnen und sich ansehen.',
-        'anweisung': 'Die beiden Verliebten öffnen kurz die Augen, lächeln sich an, und schließen sie wieder.',
-        'bedingung': {'nach_event': 'armor_verliebte'},
-        'einmalig': True,
+    "verliebte_erfahren": {
+        "text": "Die Verliebten erwachen kurz und erkennen einander. Sie dürfen die Augen öffnen und sich ansehen.",
+        "anweisung": "Die beiden Verliebten öffnen kurz die Augen, lächeln sich an, und schließen sie wieder.",
+        "bedingung": {"nach_event": "armor_verliebte"},
+        "einmalig": True,
     },
-    'wildes_kind_vorbild': {
-        'text': 'Das Wilde Kind erwacht. Es wählt ein Vorbild. Sollte dieses Vorbild sterben, wird das Kind zum Werwolf.',
-        'anweisung': 'Das Wilde Kind öffnet die Augen und zeigt auf sein Vorbild. Merke dir diese Wahl.',
-        'bedingung': {'runde': 1, 'rolle_aktiv': 'Wildes Kind'},
-        'einmalig': True,
+    "wildes_kind_vorbild": {
+        "text": "Das Wilde Kind erwacht. Es wählt ein Vorbild. Sollte dieses Vorbild sterben, wird das Kind zum Werwolf.",
+        "anweisung": "Das Wilde Kind öffnet die Augen und zeigt auf sein Vorbild. Merke dir diese Wahl.",
+        "bedingung": {"runde": 1, "rolle_aktiv": "Wildes Kind"},
+        "einmalig": True,
     },
-    'werwolf_erste_nacht': {
-        'text': 'Die Werwölfe erwachen zum ersten Mal. Sie öffnen die Augen und erkennen ihre Mitstreiter.',
-        'anweisung': 'Die Werwölfe öffnen die Augen und schauen sich an. Sie wählen noch kein Opfer - nur kennenlernen!',
-        'bedingung': {'runde': 1, 'phase': 'werwolf'},
-        'einmalig': True,
+    "werwolf_erste_nacht": {
+        "text": "Die Werwölfe erwachen zum ersten Mal. Sie öffnen die Augen und erkennen ihre Mitstreiter.",
+        "anweisung": "Die Werwölfe öffnen die Augen und schauen sich an. Sie wählen noch kein Opfer - nur kennenlernen!",
+        "bedingung": {"runde": 1, "phase": "werwolf"},
+        "einmalig": True,
     },
-    'drei_brueder_treffen': {
-        'text': 'Die drei Brüder erwachen. Sie öffnen die Augen und erkennen einander als Verbündete.',
-        'anweisung': 'Die Brüder öffnen kurz die Augen und schauen sich an.',
-        'bedingung': {'runde': 1, 'rolle_aktiv': 'Drei Brüder'},
-        'einmalig': True,
+    "drei_brueder_treffen": {
+        "text": "Die drei Brüder erwachen. Sie öffnen die Augen und erkennen einander als Verbündete.",
+        "anweisung": "Die Brüder öffnen kurz die Augen und schauen sich an.",
+        "bedingung": {"runde": 1, "rolle_aktiv": "Drei Brüder"},
+        "einmalig": True,
     },
-    'zwei_schwestern_treffen': {
-        'text': 'Die zwei Schwestern erwachen. Sie erkennen einander als Verbündete.',
-        'anweisung': 'Die Schwestern öffnen kurz die Augen und schauen sich an.',
-        'bedingung': {'runde': 1, 'rolle_aktiv': 'Zwei Schwestern'},
-        'einmalig': True,
+    "zwei_schwestern_treffen": {
+        "text": "Die zwei Schwestern erwachen. Sie erkennen einander als Verbündete.",
+        "anweisung": "Die Schwestern öffnen kurz die Augen und schauen sich an.",
+        "bedingung": {"runde": 1, "rolle_aktiv": "Zwei Schwestern"},
+        "einmalig": True,
     },
-    'freimaurer_treffen': {
-        'text': 'Die Freimaurer erwachen. Sie erkennen ihre Logenbrüder und wissen, wem sie vertrauen können.',
-        'anweisung': 'Die Freimaurer öffnen die Augen und schauen sich an.',
-        'bedingung': {'runde': 1, 'rolle_aktiv': 'Freimaurer'},
-        'einmalig': True,
+    "freimaurer_treffen": {
+        "text": "Die Freimaurer erwachen. Sie erkennen ihre Logenbrüder und wissen, wem sie vertrauen können.",
+        "anweisung": "Die Freimaurer öffnen die Augen und schauen sich an.",
+        "bedingung": {"runde": 1, "rolle_aktiv": "Freimaurer"},
+        "einmalig": True,
     },
-    'doppelgaenger_wahl': {
-        'text': 'Der Doppelgänger erwacht. Er wählt einen Spieler, dessen Rolle er übernehmen wird, sollte dieser sterben.',
-        'anweisung': 'Der Doppelgänger zeigt auf einen Spieler. Merke dir diese Wahl.',
-        'bedingung': {'runde': 1, 'rolle_aktiv': 'Doppelgänger'},
-        'einmalig': True,
+    "doppelgaenger_wahl": {
+        "text": "Der Doppelgänger erwacht. Er wählt einen Spieler, dessen Rolle er übernehmen wird, sollte dieser sterben.",
+        "anweisung": "Der Doppelgänger zeigt auf einen Spieler. Merke dir diese Wahl.",
+        "bedingung": {"runde": 1, "rolle_aktiv": "Doppelgänger"},
+        "einmalig": True,
     },
-    'hund_herrchen': {
-        'text': 'Der Hund erwacht. Er wählt sein Herrchen. Stirbt sein Herrchen, wird der Hund zum Werwolf!',
-        'anweisung': 'Der Hund öffnet die Augen und zeigt auf sein Herrchen. Merke dir diese Wahl.',
-        'bedingung': {'runde': 1, 'rolle_aktiv': 'Hund'},
-        'einmalig': True,
+    "hund_herrchen": {
+        "text": "Der Hund erwacht. Er wählt sein Herrchen. Stirbt sein Herrchen, wird der Hund zum Werwolf!",
+        "anweisung": "Der Hund öffnet die Augen und zeigt auf sein Herrchen. Merke dir diese Wahl.",
+        "bedingung": {"runde": 1, "rolle_aktiv": "Hund"},
+        "einmalig": True,
     },
-    
     # === EREIGNIS-EVENTS (passieren bei bestimmten Aktionen) ===
-    'jaeger_stirbt': {
-        'text': 'Der Jäger wurde getötet! Mit seinem letzten Atemzug greift er zur Flinte und feuert einen finalen Schuss ab!',
-        'anweisung': 'Der Jäger öffnet die Augen und zeigt auf sein Opfer. Dieses stirbt sofort.',
-        'bedingung': {'trigger': 'spieler_stirbt', 'rolle': 'Jäger'},
-        'einmalig': False,  # Kann bei mehreren Jägern mehrfach passieren
+    "jaeger_stirbt": {
+        "text": "Der Jäger wurde getötet! Mit seinem letzten Atemzug greift er zur Flinte und feuert einen finalen Schuss ab!",
+        "anweisung": "Der Jäger öffnet die Augen und zeigt auf sein Opfer. Dieses stirbt sofort.",
+        "bedingung": {"trigger": "spieler_stirbt", "rolle": "Jäger"},
+        "einmalig": False,  # Kann bei mehreren Jägern mehrfach passieren
     },
-    'hexe_heiltrank_leer': {
-        'text': 'Die Hexe hat ihren Heiltrank bereits verbraucht.',
-        'anweisung': 'Zeige der Hexe, dass sie nicht heilen kann (Kopfschütteln).',
-        'bedingung': {'trigger': 'hexe_kein_heiltrank'},
-        'einmalig': True,
+    "hexe_heiltrank_leer": {
+        "text": "Die Hexe hat ihren Heiltrank bereits verbraucht.",
+        "anweisung": "Zeige der Hexe, dass sie nicht heilen kann (Kopfschütteln).",
+        "bedingung": {"trigger": "hexe_kein_heiltrank"},
+        "einmalig": True,
     },
-    'hexe_gifttrank_leer': {
-        'text': 'Die Hexe hat ihren Gifttrank bereits verbraucht.',
-        'anweisung': 'Zeige der Hexe, dass sie nicht vergiften kann.',
-        'bedingung': {'trigger': 'hexe_kein_gifttrank'},
-        'einmalig': True,
+    "hexe_gifttrank_leer": {
+        "text": "Die Hexe hat ihren Gifttrank bereits verbraucht.",
+        "anweisung": "Zeige der Hexe, dass sie nicht vergiften kann.",
+        "bedingung": {"trigger": "hexe_kein_gifttrank"},
+        "einmalig": True,
     },
-    'urwolf_infiziert': {
-        'text': 'Der Urwolf hat sein Opfer infiziert statt getötet! Das Opfer wird zum Werwolf erwachen...',
-        'anweisung': 'Berühre das Opfer leicht - es wird in der nächsten Nacht als Werwolf erwachen.',
-        'bedingung': {'trigger': 'urwolf_infektion'},
-        'einmalig': True,
+    "urwolf_infiziert": {
+        "text": "Der Urwolf hat sein Opfer infiziert statt getötet! Das Opfer wird zum Werwolf erwachen...",
+        "anweisung": "Berühre das Opfer leicht - es wird in der nächsten Nacht als Werwolf erwachen.",
+        "bedingung": {"trigger": "urwolf_infektion"},
+        "einmalig": True,
     },
-    'wildes_kind_verwandelt': {
-        'text': 'Das Vorbild des Wilden Kindes ist gestorben! Das Kind verwandelt sich in einen Werwolf!',
-        'anweisung': 'Das Wilde Kind wird in der nächsten Nacht mit den Werwölfen aufwachen.',
-        'bedingung': {'trigger': 'vorbild_stirbt'},
-        'einmalig': True,
+    "wildes_kind_verwandelt": {
+        "text": "Das Vorbild des Wilden Kindes ist gestorben! Das Kind verwandelt sich in einen Werwolf!",
+        "anweisung": "Das Wilde Kind wird in der nächsten Nacht mit den Werwölfen aufwachen.",
+        "bedingung": {"trigger": "vorbild_stirbt"},
+        "einmalig": True,
     },
-    'hund_verwandelt': {
-        'text': 'Das Herrchen des Hundes ist gestorben! Der treue Hund verwandelt sich vor Trauer in einen Werwolf!',
-        'anweisung': 'Der Hund wird in der nächsten Nacht mit den Werwölfen aufwachen.',
-        'bedingung': {'trigger': 'herrchen_stirbt'},
-        'einmalig': True,
+    "hund_verwandelt": {
+        "text": "Das Herrchen des Hundes ist gestorben! Der treue Hund verwandelt sich vor Trauer in einen Werwolf!",
+        "anweisung": "Der Hund wird in der nächsten Nacht mit den Werwölfen aufwachen.",
+        "bedingung": {"trigger": "herrchen_stirbt"},
+        "einmalig": True,
     },
-    'jesus_aufersteht': {
-        'text': 'Jesus ist gestorben... aber wartet! Nach drei Tagen ist er wieder auferstanden!',
-        'anweisung': 'Jesus kehrt ins Spiel zurück. Ein Wunder!',
-        'bedingung': {'trigger': 'jesus_auferstehung'},
-        'einmalig': True,
+    "jesus_aufersteht": {
+        "text": "Jesus ist gestorben... aber wartet! Nach drei Tagen ist er wieder auferstanden!",
+        "anweisung": "Jesus kehrt ins Spiel zurück. Ein Wunder!",
+        "bedingung": {"trigger": "jesus_auferstehung"},
+        "einmalig": True,
     },
-    'alter_mann_stirbt_dorf': {
-        'text': 'Der Alte Mann wurde vom Dorf hingerichtet! Vor Enttäuschung verflucht er das Dorf - alle Spezialrollen verlieren ihre Fähigkeiten!',
-        'anweisung': 'Seherin, Hexe, Heiler etc. verlieren ihre Nachtaktionen.',
-        'bedingung': {'trigger': 'alter_mann_gehaengt'},
-        'einmalig': True,
+    "alter_mann_stirbt_dorf": {
+        "text": "Der Alte Mann wurde vom Dorf hingerichtet! Vor Enttäuschung verflucht er das Dorf - alle Spezialrollen verlieren ihre Fähigkeiten!",
+        "anweisung": "Seherin, Hexe, Heiler etc. verlieren ihre Nachtaktionen.",
+        "bedingung": {"trigger": "alter_mann_gehaengt"},
+        "einmalig": True,
     },
-    'pyromane_zuendet': {
-        'text': 'Der Pyromane hat ein Haus angezündet! Das Feuer breitet sich aus und tötet auch die Nachbarn!',
-        'anweisung': 'Der Pyromane und seine beiden Nachbarn sterben in den Flammen.',
-        'bedingung': {'trigger': 'pyromane_aktion'},
-        'einmalig': True,
+    "pyromane_zuendet": {
+        "text": "Der Pyromane hat ein Haus angezündet! Das Feuer breitet sich aus und tötet auch die Nachbarn!",
+        "anweisung": "Der Pyromane und seine beiden Nachbarn sterben in den Flammen.",
+        "bedingung": {"trigger": "pyromane_aktion"},
+        "einmalig": True,
     },
-    
     # === SPIELENDE EVENTS ===
-    'dorf_gewonnen': {
-        'text': 'Das Dorf hat gewonnen! Alle Werwölfe wurden eliminiert. Die Dorfbewohner können wieder in Frieden leben.',
-        'anweisung': 'Gratuliere dem Dorf! Decke alle Rollen auf.',
-        'bedingung': {'trigger': 'spielende', 'gewinner': 'dorf'},
-        'einmalig': True,
+    "dorf_gewonnen": {
+        "text": "Das Dorf hat gewonnen! Alle Werwölfe wurden eliminiert. Die Dorfbewohner können wieder in Frieden leben.",
+        "anweisung": "Gratuliere dem Dorf! Decke alle Rollen auf.",
+        "bedingung": {"trigger": "spielende", "gewinner": "dorf"},
+        "einmalig": True,
     },
-    'werwolf_gewonnen': {
-        'text': 'Die Werwölfe haben gewonnen! Sie sind nun in der Überzahl und übernehmen das Dorf.',
-        'anweisung': 'Die Werwölfe haben gewonnen. Decke alle Rollen auf.',
-        'bedingung': {'trigger': 'spielende', 'gewinner': 'werwolf'},
-        'einmalig': True,
+    "werwolf_gewonnen": {
+        "text": "Die Werwölfe haben gewonnen! Sie sind nun in der Überzahl und übernehmen das Dorf.",
+        "anweisung": "Die Werwölfe haben gewonnen. Decke alle Rollen auf.",
+        "bedingung": {"trigger": "spielende", "gewinner": "werwolf"},
+        "einmalig": True,
     },
-    'verliebte_gewonnen': {
-        'text': 'Die Verliebten haben gewonnen! Ihre Liebe hat alle Hindernisse überwunden. Sie sind die letzten Überlebenden.',
-        'anweisung': 'Die Verliebten sind die letzten Überlebenden. Romantisches Ende!',
-        'bedingung': {'trigger': 'spielende', 'gewinner': 'verliebte'},
-        'einmalig': True,
+    "verliebte_gewonnen": {
+        "text": "Die Verliebten haben gewonnen! Ihre Liebe hat alle Hindernisse überwunden. Sie sind die letzten Überlebenden.",
+        "anweisung": "Die Verliebten sind die letzten Überlebenden. Romantisches Ende!",
+        "bedingung": {"trigger": "spielende", "gewinner": "verliebte"},
+        "einmalig": True,
     },
-    'selbstmoerder_gewonnen': {
-        'text': 'Der Selbstmörder hat es geschafft! Er wurde vom Dorf hingerichtet und hat sein Ziel erreicht.',
-        'anweisung': 'Der Selbstmörder gewinnt alleine!',
-        'bedingung': {'trigger': 'spielende', 'gewinner': 'selbstmoerder'},
-        'einmalig': True,
+    "selbstmoerder_gewonnen": {
+        "text": "Der Selbstmörder hat es geschafft! Er wurde vom Dorf hingerichtet und hat sein Ziel erreicht.",
+        "anweisung": "Der Selbstmörder gewinnt alleine!",
+        "bedingung": {"trigger": "spielende", "gewinner": "selbstmoerder"},
+        "einmalig": True,
     },
 }
+
 
 # Hilfsfunktion zum Abrufen des richtigen Erzähler-Texts
 def hole_erzaehler_text(raum_id, event_typ, kontext=None):
@@ -455,27 +487,27 @@ def hole_erzaehler_text(raum_id, event_typ, kontext=None):
     kontext: Dict mit Variablen für Platzhalter (z.B. {opfer}, {spieler})
     """
     # Prüfe ob Event bereits gespielt
-    if ERZAEHLER_EVENTS.get(event_typ, {}).get('einmalig', True):
+    if ERZAEHLER_EVENTS.get(event_typ, {}).get("einmalig", True):
         if ErzaehlerEvent.event_bereits_gespielt(raum_id, event_typ):
             return None
-    
+
     event = ERZAEHLER_EVENTS.get(event_typ) or ERZAEHLER_PHASEN.get(event_typ)
     if not event:
         return None
-    
-    text = event['text']
-    anweisung = event.get('anweisung', '')
-    
+
+    text = event["text"]
+    anweisung = event.get("anweisung", "")
+
     # Platzhalter ersetzen
     if kontext:
         for key, value in kontext.items():
-            text = text.replace('{' + key + '}', str(value))
-            anweisung = anweisung.replace('{' + key + '}', str(value))
-    
+            text = text.replace("{" + key + "}", str(value))
+            anweisung = anweisung.replace("{" + key + "}", str(value))
+
     return {
-        'text': text,
-        'anweisung': anweisung,
-        'einmalig': event.get('einmalig', False),
+        "text": text,
+        "anweisung": anweisung,
+        "einmalig": event.get("einmalig", False),
     }
 
 
@@ -490,109 +522,109 @@ ERZAEHLER_TEXTE = ERZAEHLER_PHASEN
 # ============================================================================
 
 HINWEIS_TYPEN = {
-    'augen_flackern': {
-        'name': 'Augen-Flackern',
-        'beschreibung': 'Das Avatar-Bild des Spielers flackert kurz rot',
-        'dauer_ms': 150,
-        'css_class': 'hint-eyes-flicker',
-        'audio': None,
-        'verdaechtigkeit': 0.3,  # Wie verdächtig ist dieser Hinweis (0-1)
+    "augen_flackern": {
+        "name": "Augen-Flackern",
+        "beschreibung": "Das Avatar-Bild des Spielers flackert kurz rot",
+        "dauer_ms": 150,
+        "css_class": "hint-eyes-flicker",
+        "audio": None,
+        "verdaechtigkeit": 0.3,  # Wie verdächtig ist dieser Hinweis (0-1)
     },
-    'schatten': {
-        'name': 'Schatten',
-        'beschreibung': 'Ein kurzer Schatten huscht über den Spieler',
-        'dauer_ms': 300,
-        'css_class': 'hint-shadow',
-        'audio': 'shadow_swoosh.mp3',
-        'verdaechtigkeit': 0.2,
+    "schatten": {
+        "name": "Schatten",
+        "beschreibung": "Ein kurzer Schatten huscht über den Spieler",
+        "dauer_ms": 300,
+        "css_class": "hint-shadow",
+        "audio": "shadow_swoosh.mp3",
+        "verdaechtigkeit": 0.2,
     },
-    'heulen_fern': {
-        'name': 'Fernes Heulen',
-        'beschreibung': 'Ein leises, fernes Wolfsheulen ist zu hören',
-        'dauer_ms': 2000,
-        'css_class': None,
-        'audio': 'distant_howl.mp3',
-        'verdaechtigkeit': 0.4,
+    "heulen_fern": {
+        "name": "Fernes Heulen",
+        "beschreibung": "Ein leises, fernes Wolfsheulen ist zu hören",
+        "dauer_ms": 2000,
+        "css_class": None,
+        "audio": "distant_howl.mp3",
+        "verdaechtigkeit": 0.4,
     },
-    'mond_schein': {
-        'name': 'Mondschein',
-        'beschreibung': 'Mondlicht erhellt kurz den Spieler',
-        'dauer_ms': 500,
-        'css_class': 'hint-moonlight',
-        'audio': None,
-        'verdaechtigkeit': 0.25,
+    "mond_schein": {
+        "name": "Mondschein",
+        "beschreibung": "Mondlicht erhellt kurz den Spieler",
+        "dauer_ms": 500,
+        "css_class": "hint-moonlight",
+        "audio": None,
+        "verdaechtigkeit": 0.25,
     },
-    'nervoes': {
-        'name': 'Nervöses Zittern',
-        'beschreibung': 'Die Spielerkarte zittert leicht',
-        'dauer_ms': 800,
-        'css_class': 'hint-nervous',
-        'audio': None,
-        'verdaechtigkeit': 0.15,
+    "nervoes": {
+        "name": "Nervöses Zittern",
+        "beschreibung": "Die Spielerkarte zittert leicht",
+        "dauer_ms": 800,
+        "css_class": "hint-nervous",
+        "audio": None,
+        "verdaechtigkeit": 0.15,
     },
-    'blick_abwenden': {
-        'name': 'Blick abwenden',
-        'beschreibung': 'Das Avatar dreht sich kurz weg',
-        'dauer_ms': 400,
-        'css_class': 'hint-look-away',
-        'audio': None,
-        'verdaechtigkeit': 0.2,
+    "blick_abwenden": {
+        "name": "Blick abwenden",
+        "beschreibung": "Das Avatar dreht sich kurz weg",
+        "dauer_ms": 400,
+        "css_class": "hint-look-away",
+        "audio": None,
+        "verdaechtigkeit": 0.2,
     },
-    'kratzen': {
-        'name': 'Kratzen',
-        'beschreibung': 'Ein Kratzgeräusch ist zu hören',
-        'dauer_ms': 1000,
-        'css_class': None,
-        'audio': 'scratch.mp3',
-        'verdaechtigkeit': 0.35,
+    "kratzen": {
+        "name": "Kratzen",
+        "beschreibung": "Ein Kratzgeräusch ist zu hören",
+        "dauer_ms": 1000,
+        "css_class": None,
+        "audio": "scratch.mp3",
+        "verdaechtigkeit": 0.35,
     },
-    'herzschlag': {
-        'name': 'Schneller Herzschlag',
-        'beschreibung': 'Ein schneller Herzschlag pulsiert',
-        'dauer_ms': 1500,
-        'css_class': 'hint-heartbeat',
-        'audio': 'heartbeat_fast.mp3',
-        'verdaechtigkeit': 0.3,
+    "herzschlag": {
+        "name": "Schneller Herzschlag",
+        "beschreibung": "Ein schneller Herzschlag pulsiert",
+        "dauer_ms": 1500,
+        "css_class": "hint-heartbeat",
+        "audio": "heartbeat_fast.mp3",
+        "verdaechtigkeit": 0.3,
     },
-    'gluehen': {
-        'name': 'Mystisches Glühen',
-        'beschreibung': 'Ein mystisches Glühen umgibt den Spieler',
-        'dauer_ms': 600,
-        'css_class': 'hint-glow',
-        'audio': None,
-        'verdaechtigkeit': 0.1,  # Niedriger, da auch gute Rollen glühen
+    "gluehen": {
+        "name": "Mystisches Glühen",
+        "beschreibung": "Ein mystisches Glühen umgibt den Spieler",
+        "dauer_ms": 600,
+        "css_class": "hint-glow",
+        "audio": None,
+        "verdaechtigkeit": 0.1,  # Niedriger, da auch gute Rollen glühen
     },
-    'fluestern': {
-        'name': 'Flüstern',
-        'beschreibung': 'Unverständliches Flüstern ist zu hören',
-        'dauer_ms': 1200,
-        'css_class': None,
-        'audio': 'whisper.mp3',
-        'verdaechtigkeit': 0.25,
+    "fluestern": {
+        "name": "Flüstern",
+        "beschreibung": "Unverständliches Flüstern ist zu hören",
+        "dauer_ms": 1200,
+        "css_class": None,
+        "audio": "whisper.mp3",
+        "verdaechtigkeit": 0.25,
     },
-    'selbst_verdaechtigung': {
-        'name': 'Selbst-Verdächtigung',
-        'beschreibung': 'Der Spieler macht sich selbst verdächtig (Selbstmörder)',
-        'dauer_ms': 1000,
-        'css_class': 'hint-sus-self',
-        'audio': 'suspicious.mp3',
-        'verdaechtigkeit': 0.5,  # Spieler-kontrolliert
+    "selbst_verdaechtigung": {
+        "name": "Selbst-Verdächtigung",
+        "beschreibung": "Der Spieler macht sich selbst verdächtig (Selbstmörder)",
+        "dauer_ms": 1000,
+        "css_class": "hint-sus-self",
+        "audio": "suspicious.mp3",
+        "verdaechtigkeit": 0.5,  # Spieler-kontrolliert
     },
-    'stolpern': {
-        'name': 'Stolpern',
-        'beschreibung': 'Der Spieler scheint zu stolpern',
-        'dauer_ms': 500,
-        'css_class': 'hint-stumble',
-        'audio': 'stumble.mp3',
-        'verdaechtigkeit': 0.1,
+    "stolpern": {
+        "name": "Stolpern",
+        "beschreibung": "Der Spieler scheint zu stolpern",
+        "dauer_ms": 500,
+        "css_class": "hint-stumble",
+        "audio": "stumble.mp3",
+        "verdaechtigkeit": 0.1,
     },
-    'kichern': {
-        'name': 'Böses Kichern',
-        'beschreibung': 'Ein leises, böses Kichern',
-        'dauer_ms': 800,
-        'css_class': None,
-        'audio': 'evil_chuckle.mp3',
-        'verdaechtigkeit': 0.45,
+    "kichern": {
+        "name": "Böses Kichern",
+        "beschreibung": "Ein leises, böses Kichern",
+        "dauer_ms": 800,
+        "css_class": None,
+        "audio": "evil_chuckle.mp3",
+        "verdaechtigkeit": 0.45,
     },
 }
 
@@ -603,180 +635,185 @@ HINWEIS_TYPEN = {
 # ============================================================================
 
 HINWEIS_MODUS = {
-    'gruppe': {
+    "gruppe": {
         # Im Gruppen-Modus: Audio + Visual für den Erzähler
-        'audio_erlaubt': True,
-        'visual_ziel': 'erzaehler',  # Nur Erzähler sieht Hinweise
-        'synchronisiert': False,
+        "audio_erlaubt": True,
+        "visual_ziel": "erzaehler",  # Nur Erzähler sieht Hinweise
+        "synchronisiert": False,
     },
-    'online': {
+    "online": {
         # Im Online-Modus: NUR Visual, SYNCHRONISIERT für alle!
-        'audio_erlaubt': False,  # Kein Audio im Remote Play!
-        'visual_ziel': 'alle',  # Alle sehen den Hinweis gleichzeitig
-        'synchronisiert': True,  # Gleicher Timestamp für alle
-        'hinweis_nachricht': True,  # Zeige Text wie "Ein Schatten huscht über {spieler}"
+        "audio_erlaubt": False,  # Kein Audio im Remote Play!
+        "visual_ziel": "alle",  # Alle sehen den Hinweis gleichzeitig
+        "synchronisiert": True,  # Gleicher Timestamp für alle
+        "hinweis_nachricht": True,  # Zeige Text wie "Ein Schatten huscht über {spieler}"
     },
 }
 
 # Hinweis-Konfiguration pro Rollen-Team
 HINWEIS_CHANCEN = {
-    'werwolf': {
+    "werwolf": {
         # Werwölfe haben höhere Chancen, verdächtige Hinweise zu produzieren
-        'basis_chance': 0.15,  # 15% Basis-Chance pro Nachtphase
-        'hinweise': ['augen_flackern', 'schatten', 'mond_schein'],  # Nur visuelle!
-        'max_pro_nacht': 2,
+        "basis_chance": 0.15,  # 15% Basis-Chance pro Nachtphase
+        "hinweise": ["augen_flackern", "schatten", "mond_schein"],  # Nur visuelle!
+        "max_pro_nacht": 2,
     },
-    'dorf': {
+    "dorf": {
         # Dorfbewohner produzieren selten Hinweise (False Positives)
-        'basis_chance': 0.05,  # 5% Basis-Chance
-        'hinweise': ['nervoes', 'stolpern', 'gluehen'],
-        'max_pro_nacht': 1,
+        "basis_chance": 0.05,  # 5% Basis-Chance
+        "hinweise": ["nervoes", "stolpern", "gluehen"],
+        "max_pro_nacht": 1,
     },
-    'solo': {
+    "solo": {
         # Solo-Rollen haben variable Hinweise
-        'basis_chance': 0.10,
-        'hinweise': ['schatten', 'blick_abwenden', 'mond_schein'],
-        'max_pro_nacht': 1,
+        "basis_chance": 0.10,
+        "hinweise": ["schatten", "blick_abwenden", "mond_schein"],
+        "max_pro_nacht": 1,
     },
-    'neutral': {
-        'basis_chance': 0.08,
-        'hinweise': ['gluehen', 'mond_schein'],
-        'max_pro_nacht': 1,
+    "neutral": {
+        "basis_chance": 0.08,
+        "hinweise": ["gluehen", "mond_schein"],
+        "max_pro_nacht": 1,
     },
 }
 
 # Hinweise die ALLE Spieler sehen können (für Online-Synchronisation)
 SYNCHRONISIERTE_HINWEISE = {
-    'augen_flackern': {
-        'nachricht': 'Die Augen von {spieler} flackern kurz seltsam...',
-        '3d_effekt': 'eyes_glow_red',  # 3D-Visualisierung
+    "augen_flackern": {
+        "nachricht": "Die Augen von {spieler} flackern kurz seltsam...",
+        "3d_effekt": "eyes_glow_red",  # 3D-Visualisierung
     },
-    'schatten': {
-        'nachricht': 'Ein Schatten huscht über {spieler}...',
-        '3d_effekt': 'shadow_pass',
+    "schatten": {
+        "nachricht": "Ein Schatten huscht über {spieler}...",
+        "3d_effekt": "shadow_pass",
     },
-    'mond_schein': {
-        'nachricht': 'Mondlicht fällt auf {spieler}...',
-        '3d_effekt': 'moonbeam',
+    "mond_schein": {
+        "nachricht": "Mondlicht fällt auf {spieler}...",
+        "3d_effekt": "moonbeam",
     },
-    'nervoes': {
-        'nachricht': '{spieler} wirkt nervös...',
-        '3d_effekt': 'character_shake',
+    "nervoes": {
+        "nachricht": "{spieler} wirkt nervös...",
+        "3d_effekt": "character_shake",
     },
-    'stolpern': {
-        'nachricht': '{spieler} stolpert kurz...',
-        '3d_effekt': 'character_stumble',
+    "stolpern": {
+        "nachricht": "{spieler} stolpert kurz...",
+        "3d_effekt": "character_stumble",
     },
-    'gluehen': {
-        'nachricht': 'Ein mystisches Glühen umgibt {spieler}...',
-        '3d_effekt': 'aura_glow',
+    "gluehen": {
+        "nachricht": "Ein mystisches Glühen umgibt {spieler}...",
+        "3d_effekt": "aura_glow",
     },
-    'blick_abwenden': {
-        'nachricht': '{spieler} wendet den Blick ab...',
-        '3d_effekt': 'look_away',
+    "blick_abwenden": {
+        "nachricht": "{spieler} wendet den Blick ab...",
+        "3d_effekt": "look_away",
     },
-    'selbst_verdaechtigung': {
-        'nachricht': '{spieler} verhält sich verdächtig!',
-        '3d_effekt': 'suspicious_behavior',
+    "selbst_verdaechtigung": {
+        "nachricht": "{spieler} verhält sich verdächtig!",
+        "3d_effekt": "suspicious_behavior",
     },
 }
 
 # Spezielle Rollen-Hinweise (überschreiben Team-Standard)
 SPEZIAL_HINWEISE = {
-    'Selbstmörder': {
+    "Selbstmörder": {
         # Der Selbstmörder kann aktiv Hinweise auf sich ziehen!
-        'kann_hinweis_senden': True,
-        'verfuegbare_hinweise': ['selbst_verdaechtigung', 'nervoes', 'stolpern', 'blick_abwenden'],
-        'hinweise_pro_tag': 3,  # Kann 3x pro Tag sich verdächtig machen
-        'beschreibung': 'Klicke auf "Verdächtig wirken" um subtile Hinweise zu senden.',
+        "kann_hinweis_senden": True,
+        "verfuegbare_hinweise": [
+            "selbst_verdaechtigung",
+            "nervoes",
+            "stolpern",
+            "blick_abwenden",
+        ],
+        "hinweise_pro_tag": 3,  # Kann 3x pro Tag sich verdächtig machen
+        "beschreibung": 'Klicke auf "Verdächtig wirken" um subtile Hinweise zu senden.',
     },
-    'Gerber': {
-        'kann_hinweis_senden': True,
-        'verfuegbare_hinweise': ['selbst_verdaechtigung', 'nervoes'],
-        'hinweise_pro_tag': 2,
-        'beschreibung': 'Du kannst dich verdächtig machen, um gehängt zu werden.',
+    "Gerber": {
+        "kann_hinweis_senden": True,
+        "verfuegbare_hinweise": ["selbst_verdaechtigung", "nervoes"],
+        "hinweise_pro_tag": 2,
+        "beschreibung": "Du kannst dich verdächtig machen, um gehängt zu werden.",
     },
-    'Dorfdepp': {
-        'kann_hinweis_senden': True,
-        'verfuegbare_hinweise': ['stolpern', 'nervoes'],
-        'hinweise_pro_tag': 2,
-        'beschreibung': 'Mach dich zum Deppen und wirke verdächtig!',
+    "Dorfdepp": {
+        "kann_hinweis_senden": True,
+        "verfuegbare_hinweise": ["stolpern", "nervoes"],
+        "hinweise_pro_tag": 2,
+        "beschreibung": "Mach dich zum Deppen und wirke verdächtig!",
     },
-    'Engel': {
-        'kann_hinweis_senden': True,
-        'verfuegbare_hinweise': ['gluehen', 'selbst_verdaechtigung'],
-        'hinweise_pro_tag': 2,
-        'beschreibung': 'Du musst in der ersten Runde sterben! Ziehe Aufmerksamkeit auf dich.',
+    "Engel": {
+        "kann_hinweis_senden": True,
+        "verfuegbare_hinweise": ["gluehen", "selbst_verdaechtigung"],
+        "hinweise_pro_tag": 2,
+        "beschreibung": "Du musst in der ersten Runde sterben! Ziehe Aufmerksamkeit auf dich.",
     },
-    'Weißer Wolf': {
+    "Weißer Wolf": {
         # Besonders unauffällig unter Wölfen
-        'basis_chance_override': 0.08,  # Niedrigere Chance als normale Werwölfe
-        'hinweise': ['schatten'],
+        "basis_chance_override": 0.08,  # Niedrigere Chance als normale Werwölfe
+        "hinweise": ["schatten"],
     },
-    'Wolfshund': {
+    "Wolfshund": {
         # Je nach Entscheidung verschiedene Hinweise
-        'dynamisch': True,
+        "dynamisch": True,
     },
 }
 
 # Spielregeln/Varianten für Regelauswahl
 SPIEL_REGELN = {
-    'standard': {
-        'name': 'Standard-Regeln',
-        'beschreibung': 'Die klassischen Werwolf-Regeln.',
-        'einstellungen': {
-            'nacht_zeit_sekunden': 60,
-            'tag_diskussion_minuten': 5,
-            'abstimmung_zeit_sekunden': 30,
-            'tote_duerfen_reden': False,
-            'rolle_bei_tod_zeigen': True,
+    "standard": {
+        "name": "Standard-Regeln",
+        "beschreibung": "Die klassischen Werwolf-Regeln.",
+        "einstellungen": {
+            "nacht_zeit_sekunden": 60,
+            "tag_diskussion_minuten": 5,
+            "abstimmung_zeit_sekunden": 30,
+            "tote_duerfen_reden": False,
+            "rolle_bei_tod_zeigen": True,
         },
     },
-    'schnell': {
-        'name': 'Schnellspiel',
-        'beschreibung': 'Kürzere Zeiten für schnelle Runden.',
-        'einstellungen': {
-            'nacht_zeit_sekunden': 30,
-            'tag_diskussion_minuten': 2,
-            'abstimmung_zeit_sekunden': 15,
-            'tote_duerfen_reden': False,
-            'rolle_bei_tod_zeigen': True,
+    "schnell": {
+        "name": "Schnellspiel",
+        "beschreibung": "Kürzere Zeiten für schnelle Runden.",
+        "einstellungen": {
+            "nacht_zeit_sekunden": 30,
+            "tag_diskussion_minuten": 2,
+            "abstimmung_zeit_sekunden": 15,
+            "tote_duerfen_reden": False,
+            "rolle_bei_tod_zeigen": True,
         },
     },
-    'chaos': {
-        'name': 'Chaos-Modus',
-        'beschreibung': 'Mehr Zufallselemente und Überraschungen.',
-        'einstellungen': {
-            'nacht_zeit_sekunden': 45,
-            'tag_diskussion_minuten': 3,
-            'abstimmung_zeit_sekunden': 20,
-            'tote_duerfen_reden': True,  # Geister dürfen flüstern
-            'rolle_bei_tod_zeigen': False,  # Rollen bleiben geheim
-            'zufalls_ereignisse': True,
+    "chaos": {
+        "name": "Chaos-Modus",
+        "beschreibung": "Mehr Zufallselemente und Überraschungen.",
+        "einstellungen": {
+            "nacht_zeit_sekunden": 45,
+            "tag_diskussion_minuten": 3,
+            "abstimmung_zeit_sekunden": 20,
+            "tote_duerfen_reden": True,  # Geister dürfen flüstern
+            "rolle_bei_tod_zeigen": False,  # Rollen bleiben geheim
+            "zufalls_ereignisse": True,
         },
     },
-    'profi': {
-        'name': 'Profi-Modus',
-        'beschreibung': 'Für erfahrene Spieler. Weniger Hinweise, mehr Strategie.',
-        'einstellungen': {
-            'nacht_zeit_sekunden': 90,
-            'tag_diskussion_minuten': 7,
-            'abstimmung_zeit_sekunden': 45,
-            'tote_duerfen_reden': False,
-            'rolle_bei_tod_zeigen': False,
-            'hinweise_aktiviert': False,  # Keine visuellen Hinweise
+    "profi": {
+        "name": "Profi-Modus",
+        "beschreibung": "Für erfahrene Spieler. Weniger Hinweise, mehr Strategie.",
+        "einstellungen": {
+            "nacht_zeit_sekunden": 90,
+            "tag_diskussion_minuten": 7,
+            "abstimmung_zeit_sekunden": 45,
+            "tote_duerfen_reden": False,
+            "rolle_bei_tod_zeigen": False,
+            "hinweise_aktiviert": False,  # Keine visuellen Hinweise
         },
     },
-    'party': {
-        'name': 'Party-Modus',
-        'beschreibung': 'Lockere Regeln für Partys und große Gruppen.',
-        'einstellungen': {
-            'nacht_zeit_sekunden': 45,
-            'tag_diskussion_minuten': 4,
-            'abstimmung_zeit_sekunden': 20,
-            'tote_duerfen_reden': True,
-            'rolle_bei_tod_zeigen': True,
-            'mehrfach_stimmen_erlaubt': True,
+    "party": {
+        "name": "Party-Modus",
+        "beschreibung": "Lockere Regeln für Partys und große Gruppen.",
+        "einstellungen": {
+            "nacht_zeit_sekunden": 45,
+            "tag_diskussion_minuten": 4,
+            "abstimmung_zeit_sekunden": 20,
+            "tote_duerfen_reden": True,
+            "rolle_bei_tod_zeigen": True,
+            "mehrfach_stimmen_erlaubt": True,
         },
     },
 }
@@ -798,15 +835,17 @@ SPIEL_REGELN = {
 # Um eine neue Rolle hinzuzufuegen: Einfach eine .py-Datei in roles/ erstellen!
 # ============================================================================
 
+
 def _erstelle_rollen_dict():
     """
     Erstellt das ROLLEN-Dict dynamisch aus dem modularen System (roles/*.py).
-    
+
     Neue Rollen einfach als .py-Datei in roles/ hinzufuegen - sie werden
     automatisch erkannt und registriert!
     """
     try:
         from roles import get_alle_rollen
+
         return get_alle_rollen()
     except Exception as e:
         print(f"[ROLLEN] Fehler beim Laden: {e}")
@@ -825,9 +864,9 @@ def _erstelle_phasen_liste():
     Ergänzend werden die allgemeinen Tag- und Spezial-Phasen angefügt.
     """
     basis_phasen = [
-        'lobby',
-        'rollen_verteilt',
-        'nacht_start',
+        "lobby",
+        "rollen_verteilt",
+        "nacht_start",
     ]
 
     dynamische_phasen = []
@@ -841,20 +880,20 @@ def _erstelle_phasen_liste():
         print(f"[PHASEN] Fehler beim Erstellen der dynamischen Phasenliste: {e}")
 
     tag_und_spezial_phasen = [
-        'nacht_ende',
-        'tag_start',
-        'baerenbaendiger_brummen',
-        'demoskopin_info',
-        'diskussion',
-        'abstimmung',
-        'abstimmung_ergebnis',
-        'prinz_enthuellung',
-        'jaeger_phase',
-        'kamikaze_phase',
-        'hahn_enthuellung',
-        'putzfrau_info',
-        'tag_ende',
-        'spiel_ende',
+        "nacht_ende",
+        "tag_start",
+        "baerenbaendiger_brummen",
+        "demoskopin_info",
+        "diskussion",
+        "abstimmung",
+        "abstimmung_ergebnis",
+        "prinz_enthuellung",
+        "jaeger_phase",
+        "kamikaze_phase",
+        "hahn_enthuellung",
+        "putzfrau_info",
+        "tag_ende",
+        "spiel_ende",
     ]
 
     return basis_phasen + dynamische_phasen + tag_und_spezial_phasen
@@ -867,20 +906,182 @@ PHASEN = _erstelle_phasen_liste()
 # Rollen-Konfiguration nach Spielerzahl (Empfehlung)
 # For games larger than defined here, use berechne_rollen() from game_logic.py
 ROLLEN_EMPFEHLUNG = {
-    5: ['Werwolf', 'Werwolf', 'Seherin', 'Dorfbewohner', 'Dorfbewohner'],
-    6: ['Werwolf', 'Werwolf', 'Seherin', 'Hexe', 'Dorfbewohner', 'Dorfbewohner'],
-    7: ['Werwolf', 'Werwolf', 'Seherin', 'Hexe', 'Jaeger', 'Dorfbewohner', 'Dorfbewohner'],
-    8: ['Werwolf', 'Werwolf', 'Seherin', 'Hexe', 'Jaeger', 'Amor', 'Dorfbewohner', 'Dorfbewohner'],
-    9: ['Werwolf', 'Werwolf', 'Seherin', 'Hexe', 'Jaeger', 'Amor', 'Heiler', 'Dorfbewohner', 'Dorfbewohner'],
-    10: ['Werwolf', 'Werwolf', 'Werwolf', 'Seherin', 'Hexe', 'Jaeger', 'Amor', 'Heiler', 'Dorfbewohner', 'Dorfbewohner'],
-    11: ['Werwolf', 'Werwolf', 'Werwolf', 'Seherin', 'Hexe', 'Jaeger', 'Amor', 'Heiler', 'Alter Mann', 'Dorfbewohner', 'Dorfbewohner'],
-    12: ['Werwolf', 'Werwolf', 'Werwolf', 'Seherin', 'Hexe', 'Jaeger', 'Amor', 'Heiler', 'Alter Mann', 'Zwei Schwestern', 'Zwei Schwestern', 'Dorfbewohner'],
-    13: ['Werwolf', 'Werwolf', 'Werwolf', 'Weisser Wolf', 'Seherin', 'Hexe', 'Jaeger', 'Amor', 'Heiler', 'Alter Mann', 'Dorfbewohner', 'Dorfbewohner', 'Dorfbewohner'],
-    14: ['Werwolf', 'Werwolf', 'Werwolf', 'Weisser Wolf', 'Seherin', 'Hexe', 'Jaeger', 'Amor', 'Heiler', 'Alter Mann', 'Medium', 'Dorfbewohner', 'Dorfbewohner', 'Dorfbewohner'],
-    15: ['Werwolf', 'Werwolf', 'Werwolf', 'Werwolf', 'Seherin', 'Hexe', 'Jaeger', 'Amor', 'Heiler', 'Alter Mann', 'Medium', 'Rabe', 'Dorfbewohner', 'Dorfbewohner', 'Dorfbewohner'],
-    16: ['Werwolf', 'Werwolf', 'Werwolf', 'Werwolf', 'Seherin', 'Hexe', 'Jaeger', 'Amor', 'Heiler', 'Alter Mann', 'Medium', 'Rabe', 'Prinz', 'Dorfbewohner', 'Dorfbewohner', 'Dorfbewohner'],
-    17: ['Werwolf', 'Werwolf', 'Werwolf', 'Werwolf', 'Urwolf', 'Seherin', 'Hexe', 'Jaeger', 'Amor', 'Heiler', 'Alter Mann', 'Medium', 'Rabe', 'Prinz', 'Dorfbewohner', 'Dorfbewohner', 'Dorfbewohner'],
-    18: ['Werwolf', 'Werwolf', 'Werwolf', 'Werwolf', 'Urwolf', 'Seherin', 'Hexe', 'Jaeger', 'Amor', 'Heiler', 'Alter Mann', 'Medium', 'Rabe', 'Prinz', 'Floetenspieler', 'Dorfbewohner', 'Dorfbewohner', 'Dorfbewohner'],
+    5: ["Werwolf", "Werwolf", "Seherin", "Dorfbewohner", "Dorfbewohner"],
+    6: ["Werwolf", "Werwolf", "Seherin", "Hexe", "Dorfbewohner", "Dorfbewohner"],
+    7: [
+        "Werwolf",
+        "Werwolf",
+        "Seherin",
+        "Hexe",
+        "Jaeger",
+        "Dorfbewohner",
+        "Dorfbewohner",
+    ],
+    8: [
+        "Werwolf",
+        "Werwolf",
+        "Seherin",
+        "Hexe",
+        "Jaeger",
+        "Amor",
+        "Dorfbewohner",
+        "Dorfbewohner",
+    ],
+    9: [
+        "Werwolf",
+        "Werwolf",
+        "Seherin",
+        "Hexe",
+        "Jaeger",
+        "Amor",
+        "Heiler",
+        "Dorfbewohner",
+        "Dorfbewohner",
+    ],
+    10: [
+        "Werwolf",
+        "Werwolf",
+        "Werwolf",
+        "Seherin",
+        "Hexe",
+        "Jaeger",
+        "Amor",
+        "Heiler",
+        "Dorfbewohner",
+        "Dorfbewohner",
+    ],
+    11: [
+        "Werwolf",
+        "Werwolf",
+        "Werwolf",
+        "Seherin",
+        "Hexe",
+        "Jaeger",
+        "Amor",
+        "Heiler",
+        "Alter Mann",
+        "Dorfbewohner",
+        "Dorfbewohner",
+    ],
+    12: [
+        "Werwolf",
+        "Werwolf",
+        "Werwolf",
+        "Seherin",
+        "Hexe",
+        "Jaeger",
+        "Amor",
+        "Heiler",
+        "Alter Mann",
+        "Zwei Schwestern",
+        "Zwei Schwestern",
+        "Dorfbewohner",
+    ],
+    13: [
+        "Werwolf",
+        "Werwolf",
+        "Werwolf",
+        "Weisser Wolf",
+        "Seherin",
+        "Hexe",
+        "Jaeger",
+        "Amor",
+        "Heiler",
+        "Alter Mann",
+        "Dorfbewohner",
+        "Dorfbewohner",
+        "Dorfbewohner",
+    ],
+    14: [
+        "Werwolf",
+        "Werwolf",
+        "Werwolf",
+        "Weisser Wolf",
+        "Seherin",
+        "Hexe",
+        "Jaeger",
+        "Amor",
+        "Heiler",
+        "Alter Mann",
+        "Medium",
+        "Dorfbewohner",
+        "Dorfbewohner",
+        "Dorfbewohner",
+    ],
+    15: [
+        "Werwolf",
+        "Werwolf",
+        "Werwolf",
+        "Werwolf",
+        "Seherin",
+        "Hexe",
+        "Jaeger",
+        "Amor",
+        "Heiler",
+        "Alter Mann",
+        "Medium",
+        "Rabe",
+        "Dorfbewohner",
+        "Dorfbewohner",
+        "Dorfbewohner",
+    ],
+    16: [
+        "Werwolf",
+        "Werwolf",
+        "Werwolf",
+        "Werwolf",
+        "Seherin",
+        "Hexe",
+        "Jaeger",
+        "Amor",
+        "Heiler",
+        "Alter Mann",
+        "Medium",
+        "Rabe",
+        "Prinz",
+        "Dorfbewohner",
+        "Dorfbewohner",
+        "Dorfbewohner",
+    ],
+    17: [
+        "Werwolf",
+        "Werwolf",
+        "Werwolf",
+        "Werwolf",
+        "Urwolf",
+        "Seherin",
+        "Hexe",
+        "Jaeger",
+        "Amor",
+        "Heiler",
+        "Alter Mann",
+        "Medium",
+        "Rabe",
+        "Prinz",
+        "Dorfbewohner",
+        "Dorfbewohner",
+        "Dorfbewohner",
+    ],
+    18: [
+        "Werwolf",
+        "Werwolf",
+        "Werwolf",
+        "Werwolf",
+        "Urwolf",
+        "Seherin",
+        "Hexe",
+        "Jaeger",
+        "Amor",
+        "Heiler",
+        "Alter Mann",
+        "Medium",
+        "Rabe",
+        "Prinz",
+        "Floetenspieler",
+        "Dorfbewohner",
+        "Dorfbewohner",
+        "Dorfbewohner",
+    ],
 }
 
 
@@ -888,87 +1089,87 @@ def berechne_balance_statistik(spieler_anzahl: int) -> dict:
     """
     Calculate balance statistics for a given player count.
     Useful for verifying game balance.
-    
+
     Args:
         spieler_anzahl: Number of players
-        
+
     Returns:
         Dictionary with balance statistics
     """
     from game_logic import berechne_rollen
-    
+
     rollen = berechne_rollen(spieler_anzahl)
-    
+
     # Calculate team sizes
     team_dorf = 0
     team_werwolf = 0
     team_solo = 0
     team_andere = 0  # Vampire, Zombie, etc.
-    
+
     for rolle_name, anzahl in rollen.items():
-        if rolle_name == 'Erzaehler':
+        if rolle_name == "Erzaehler":
             continue
         rolle_info = ROLLEN.get(rolle_name, {})
-        team = rolle_info.get('team', 'dorf')
-        
-        if team == 'dorf':
+        team = rolle_info.get("team", "dorf")
+
+        if team == "dorf":
             team_dorf += anzahl
-        elif team == 'werwolf':
+        elif team == "werwolf":
             team_werwolf += anzahl
-        elif team == 'solo':
+        elif team == "solo":
             team_solo += anzahl
         else:
             team_andere += anzahl
-    
+
     total = team_dorf + team_werwolf + team_solo + team_andere
-    
+
     return {
-        'total_players': spieler_anzahl,
-        'team_dorf': team_dorf,
-        'team_werwolf': team_werwolf,
-        'team_solo': team_solo,
-        'team_andere': team_andere,
-        'dorf_prozent': round(team_dorf / total * 100, 1) if total > 0 else 0,
-        'werwolf_prozent': round(team_werwolf / total * 100, 1) if total > 0 else 0,
-        'solo_prozent': round(team_solo / total * 100, 1) if total > 0 else 0,
-        'andere_prozent': round(team_andere / total * 100, 1) if total > 0 else 0,
-        'rollen': rollen,
-        'balance_ratio': f"1:{round(team_dorf / team_werwolf, 1) if team_werwolf > 0 else 0}" 
+        "total_players": spieler_anzahl,
+        "team_dorf": team_dorf,
+        "team_werwolf": team_werwolf,
+        "team_solo": team_solo,
+        "team_andere": team_andere,
+        "dorf_prozent": round(team_dorf / total * 100, 1) if total > 0 else 0,
+        "werwolf_prozent": round(team_werwolf / total * 100, 1) if total > 0 else 0,
+        "solo_prozent": round(team_solo / total * 100, 1) if total > 0 else 0,
+        "andere_prozent": round(team_andere / total * 100, 1) if total > 0 else 0,
+        "rollen": rollen,
+        "balance_ratio": f"1:{round(team_dorf / team_werwolf, 1) if team_werwolf > 0 else 0}",
     }
 
 
 # Teams und ihre Gewinnbedingungen
 TEAMS = {
-    'dorf': {
-        'name': 'Das Dorf',
-        'beschreibung': 'Eliminiert alle Werwölfe und andere Bedrohungen!',
-        'farbe': '#3b82f6'
+    "dorf": {
+        "name": "Das Dorf",
+        "beschreibung": "Eliminiert alle Werwölfe und andere Bedrohungen!",
+        "farbe": "#3b82f6",
     },
-    'werwolf': {
-        'name': 'Die Werwölfe',
-        'beschreibung': 'Bringt das Dorf in die Minderheit!',
-        'farbe': '#dc2626'
+    "werwolf": {
+        "name": "Die Werwölfe",
+        "beschreibung": "Bringt das Dorf in die Minderheit!",
+        "farbe": "#dc2626",
     },
-    'vampir': {
-        'name': 'Die Vampire',
-        'beschreibung': 'Verwandelt alle lebenden Spieler in Vampire!',
-        'farbe': '#7c2d12'
+    "vampir": {
+        "name": "Die Vampire",
+        "beschreibung": "Verwandelt alle lebenden Spieler in Vampire!",
+        "farbe": "#7c2d12",
     },
-    'zombie': {
-        'name': 'Die Zombies',
-        'beschreibung': 'Infiziert alle Spieler und erreicht die Mehrheit!',
-        'farbe': '#4ade80'
+    "zombie": {
+        "name": "Die Zombies",
+        "beschreibung": "Infiziert alle Spieler und erreicht die Mehrheit!",
+        "farbe": "#4ade80",
     },
-    'solo': {
-        'name': 'Einzelspieler',
-        'beschreibung': 'Erreiche dein persönliches Ziel!',
-        'farbe': '#6b7280'
+    "solo": {
+        "name": "Einzelspieler",
+        "beschreibung": "Erreiche dein persönliches Ziel!",
+        "farbe": "#6b7280",
     },
-    'verliebte': {
-        'name': 'Die Verliebten',
-        'beschreibung': 'Überlebt gemeinsam bis zum Ende!',
-        'farbe': '#ec4899'
-    }
+    "verliebte": {
+        "name": "Die Verliebten",
+        "beschreibung": "Überlebt gemeinsam bis zum Ende!",
+        "farbe": "#ec4899",
+    },
 }
 
 
@@ -977,22 +1178,23 @@ TEAMS = {
 # Diese Funktionen nutzen das dynamische ROLLEN-Dict
 # ============================================================================
 
+
 def get_rollen_nach_kategorie():
     """
     Gibt alle Rollen gruppiert nach Kategorie zurueck.
     Format: dict[kategorie][rolle_name] = rolle_data
-    
+
     Diese Funktion wird bei jedem Aufruf neu berechnet,
     um auch zur Laufzeit hinzugefuegte Rollen zu beruecksichtigen.
     """
     kategorien = {}
     rollen_dict = _erstelle_rollen_dict()  # Frisch laden
     for rolle_name, rolle_data in rollen_dict.items():
-        kat = rolle_data.get('kategorie', 'sonstige')
+        kat = rolle_data.get("kategorie", "sonstige")
         if kat not in kategorien:
             kategorien[kat] = {}
         kategorien[kat][rolle_name] = rolle_data
-    
+
     return kategorien
 
 
@@ -1005,34 +1207,31 @@ def get_rollen_nach_kategorie_liste():
     kategorien = {}
     rollen_dict = _erstelle_rollen_dict()  # Frisch laden
     for rolle_name, rolle_data in rollen_dict.items():
-        kat = rolle_data.get('kategorie', 'sonstige')
+        kat = rolle_data.get("kategorie", "sonstige")
         if kat not in kategorien:
             kategorien[kat] = []
-        kategorien[kat].append({
-            'name': rolle_name,
-            **rolle_data
-        })
-    
+        kategorien[kat].append({"name": rolle_name, **rolle_data})
+
     # Sortiere nach ID innerhalb jeder Kategorie
     for kat in kategorien:
-        kategorien[kat].sort(key=lambda x: x.get('id', 999))
-    
+        kategorien[kat].sort(key=lambda x: x.get("id", 999))
+
     return kategorien
 
 
 # Kategorienamen fuer UI (mit schoenen deutschen Namen)
 KATEGORIE_NAMEN = {
-    'grundrollen': 'Grundrollen',
-    'dorfbewohner': 'Dorfbewohner-Varianten',
-    'werwolf': 'Werwolf-Varianten',
-    'seher': 'Sehende Rollen',
-    'hexe': 'Hexen & Zauberer',
-    'jaeger': 'Jaeger & Kaempfer',
-    'heiler': 'Heiler & Beschuetzer',
-    'spezial': 'Spezialrollen',
-    'boese': 'Boese Wesen',
-    'solo': 'Einzelkaempfer',
-    'sonstige': 'Sonstige Rollen',
+    "grundrollen": "Grundrollen",
+    "dorfbewohner": "Dorfbewohner-Varianten",
+    "werwolf": "Werwolf-Varianten",
+    "seher": "Sehende Rollen",
+    "hexe": "Hexen & Zauberer",
+    "jaeger": "Jaeger & Kaempfer",
+    "heiler": "Heiler & Beschuetzer",
+    "spezial": "Spezialrollen",
+    "boese": "Boese Wesen",
+    "solo": "Einzelkaempfer",
+    "sonstige": "Sonstige Rollen",
 }
 
 

--- a/models.py
+++ b/models.py
@@ -817,71 +817,51 @@ def _erstelle_rollen_dict():
 ROLLEN = _erstelle_rollen_dict()
 
 
+def _erstelle_phasen_liste():
+    """
+    Baut die Phasenliste dynamisch aus den registrierten Rollen.
+
+    Nachtaktive Rollen liefern ihre Phase über Role.get_phase_name().
+    Ergänzend werden die allgemeinen Tag- und Spezial-Phasen angefügt.
+    """
+    basis_phasen = [
+        'lobby',
+        'rollen_verteilt',
+        'nacht_start',
+    ]
+
+    dynamische_phasen = []
+    try:
+        from roles import RoleRegistry
+
+        dynamische_phasen = [
+            rolle.get_phase_name() for rolle in RoleRegistry.get_nacht_aktive()
+        ]
+    except Exception as e:
+        print(f"[PHASEN] Fehler beim Erstellen der dynamischen Phasenliste: {e}")
+
+    tag_und_spezial_phasen = [
+        'nacht_ende',
+        'tag_start',
+        'baerenbaendiger_brummen',
+        'demoskopin_info',
+        'diskussion',
+        'abstimmung',
+        'abstimmung_ergebnis',
+        'prinz_enthuellung',
+        'jaeger_phase',
+        'kamikaze_phase',
+        'hahn_enthuellung',
+        'putzfrau_info',
+        'tag_ende',
+        'spiel_ende',
+    ]
+
+    return basis_phasen + dynamische_phasen + tag_und_spezial_phasen
+
+
 # Spielphasen in korrekter Reihenfolge
-PHASEN = [
-    'lobby',
-    'rollen_verteilt',
-    'nacht_start',
-    # Erste-Nacht-Phasen (nur Runde 1)
-    'dieb_phase',
-    'doppelgaenger_phase',
-    'armor_phase',
-    'priester_dunkel_phase',
-    'wildes_kind_phase',
-    'hund_phase',
-    'schwestern_phase',
-    'brueder_phase',
-    'freimaurer_phase',
-    'fluechtlinge_phase',
-    'verliebte_info',
-    # Reguläre Nacht-Phasen
-    'sandmann_phase',
-    'seherin_phase',
-    'seherlehrling_phase',
-    'aurenseherin_phase',
-    'medium_phase',
-    'tratschweib_phase',
-    'paranormal_billig_phase',
-    'werwolfseherin_phase',
-    'heiler_phase',
-    'leibwaechter_phase',
-    'hure_phase',
-    'prostituierte_phase',
-    'nutte_phase',
-    'werwolf_phase',
-    'einsamerwolf_phase',
-    'urwolf_phase',
-    'weisser_wolf_phase',
-    'mordlustiger_phase',
-    'hexe_phase',
-    'hexenmeister_phase',
-    'giftmischerin_phase',
-    'kraeuterweib_phase',
-    'zauberer_phase',
-    'zahnarzt_phase',
-    'rabe_phase',
-    'floetenspieler_phase',
-    'vampir_phase',
-    'zombie_phase',
-    'pyromane_phase',
-    'tonks_phase',
-    'buddler_phase',
-    'nacht_ende',
-    # Tag-Phasen
-    'tag_start',
-    'baerenbaendiger_brummen',
-    'demoskopin_info',
-    'diskussion',
-    'abstimmung',
-    'abstimmung_ergebnis',
-    'prinz_enthuellung',
-    'jaeger_phase',
-    'kamikaze_phase',
-    'hahn_enthuellung',
-    'putzfrau_info',
-    'tag_ende',
-    'spiel_ende'
-]
+PHASEN = _erstelle_phasen_liste()
 
 
 # Rollen-Konfiguration nach Spielerzahl (Empfehlung)


### PR DESCRIPTION
## Summary
- generate phase-to-role mappings from the role registry instead of static dictionaries
- build the list of game phases dynamically from registered night-active roles while preserving shared day/special phases

## Testing
- python -m compileall models.py game_logic.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695910f079608331b3752ff495a36e7b)