### PR TITLE
Make phase mapping registry-driven

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ pip install -r requirements.txt
 python app.py
 ```
 
+### Optionale Erzähler-Stimme über ElevenLabs
+
+Wenn du die natürlich klingende ElevenLabs-Stimme nutzen möchtest, setze folgende Umgebungsvariablen:
+
+- `ENABLE_ELEVENLABS=true`
+- `ELEVENLABS_API_KEY=<dein API Key>`
+- `ELEVENLABS_VOICE_ID=g1jpii0iyvtRs8fqXsd1` (Standardstimme aus dem Beispiel)
+
+Alle erzeugten Audios werden im lokalen Cache (`static/audio/cache`) abgelegt, damit Ansagen nicht erneut generiert werden müssen.
+
 Die Anwendung läuft dann unter `http://localhost:5001`
 
 ## Spielablauf

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Webwölfe ist eine moderne, webbasierte Implementation des beliebten Gesellschaf
 
 ## Features
 
-- **Zwei Spielmodi**: 
-  - Online (jeder auf eigenem Gerät mit 3D-Dorf, automatischer Erzähler) 
+- **Zwei Spielmodi**:
+  - Online (jeder auf eigenem Gerät mit 3D-Dorf, automatischer Erzähler)
   - Gruppen-Modus (alle zusammen vor Ort, mit Erzähler-Unterstützung)
 - **Sitzordnung per Drag & Drop**: Spieler können ihre physische Sitzordnung im Kreis festlegen - wichtig für Nachbar-Mechaniken!
 - **3D-Dorfvisualisierung**: Interaktives 3D-Dorf zeigt alle Spieler im Kreis
@@ -25,6 +25,7 @@ Webwölfe ist eine moderne, webbasierte Implementation des beliebten Gesellschaf
 ## Verfügbare Rollen
 
 ### Grundrollen
+
 - **Werwolf** - Töte jede Nacht einen Dorfbewohner
 - **Dorfbewohner** - Finde und eliminiere die Werwölfe
 - **Seherin** - Erfahre die wahre Identität eines Spielers
@@ -34,6 +35,7 @@ Webwölfe ist eine moderne, webbasierte Implementation des beliebten Gesellschaf
 - **Amor** - Verliebe zwei Spieler
 
 ### Erweiterte Rollen
+
 - **Weißer Wolf** - Gewinnt alleine, kann Mitwölfe töten
 - **Urwolf** - Kann Dorfbewohner infizieren
 - **Alter Mann** - Überlebt ersten Wolfsangriff
@@ -45,6 +47,7 @@ Webwölfe ist eine moderne, webbasierte Implementation des beliebten Gesellschaf
 ## Installation
 
 ### Voraussetzungen
+
 - Python 3.10 oder höher
 - pip
 
@@ -91,12 +94,14 @@ Die Anwendung läuft dann unter `http://localhost:5001`
 ## Spielmodi
 
 ### Online-Modus
+
 - Jeder Spieler auf eigenem Gerät
 - **Kein Erzähler nötig** - das Spiel erzählt automatisch
 - Automatische Nachrichten und Anweisungen
 - Perfekt für Remote-Spielrunden
 
 ### Gruppen-Modus
+
 - Alle zusammen vor Ort
 - Mit menschlichem Erzähler
 - **Erzähler erhält vorgefertigte Texte** zum Vorlesen
@@ -135,6 +140,7 @@ webwoelfe/
 ## Sicherheit
 
 Webwölfe enthält Schutzmaßnahmen gegen Spicken:
+
 - DevTools-Erkennung (F12, Ctrl+Shift+I, etc.)
 - Rechtsklick deaktiviert
 - Console-Logging deaktiviert
@@ -157,4 +163,4 @@ Dieses Projekt steht unter der GNU General Public License v3.0 - siehe [LICENSE]
 
 ---
 
-*Inspiriert von "Werwölfe von Düsterwald" und der [Werwolf Wiki Rollen-Sammlung](https://werwolf.fandom.com/de/wiki/Werwolf-Rollen-Sammlung)*
+_Inspiriert von "Werwölfe von Düsterwald" und der [Werwolf Wiki Rollen-Sammlung](https://werwolf.fandom.com/de/wiki/Werwolf-Rollen-Sammlung)_

--- a/app.py
+++ b/app.py
@@ -2,9 +2,23 @@
 Webwoelfe - Das Online Werwolf-Spiel
 Ein Echtzeit-Multiplayer Werwolf-Spiel mit WebSocket-Unterstuetzung
 """
+
 from flask import Flask, render_template, request, session, redirect, url_for, jsonify
 from flask_socketio import SocketIO, emit, join_room, leave_room
-from models import db, Raum, Spieler, SpielAktion, SpielLog, ROLLEN, PHASEN, TEAMS, ERZAEHLER_TEXTE, get_rollen_nach_kategorie, get_rollen_nach_kategorie_liste, get_rollen_anzahl
+from models import (
+    db,
+    Raum,
+    Spieler,
+    SpielAktion,
+    SpielLog,
+    ROLLEN,
+    PHASEN,
+    TEAMS,
+    ERZAEHLER_TEXTE,
+    get_rollen_nach_kategorie,
+    get_rollen_nach_kategorie_liste,
+    get_rollen_anzahl,
+)
 from roles import get_rollen_nach_erweiterung, ERWEITERUNG_INFO, KATEGORIE_INFO
 import game_logic
 import secrets
@@ -15,16 +29,16 @@ from datetime import datetime
 
 # App Konfiguration
 app = Flask(__name__)
-app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', secrets.token_hex(32))
-app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///webwoelfe.db'
-app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY", secrets.token_hex(32))
+app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///webwoelfe.db"
+app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 
 # Spielname als Konstante
-SPIEL_NAME = 'Webwoelfe'
+SPIEL_NAME = "Webwoelfe"
 
 # Initialisierung
 db.init_app(app)
-socketio = SocketIO(app, cors_allowed_origins="*", async_mode='eventlet')
+socketio = SocketIO(app, cors_allowed_origins="*", async_mode="eventlet")
 
 # Datenbank erstellen
 with app.app_context():
@@ -35,17 +49,18 @@ with app.app_context():
 # KONTEXT-PROZESSOR - Globale Template-Variablen
 # ============================================================================
 
+
 @app.context_processor
 def inject_globals():
     """Stellt globale Variablen fuer alle Templates bereit"""
     return {
-        'spiel_name': SPIEL_NAME,
-        'alle_rollen': ROLLEN,
-        'alle_teams': TEAMS,
-        'rollen_nach_kategorie': get_rollen_nach_kategorie(),
-        'rollen_nach_erweiterung': get_rollen_nach_erweiterung(),
-        'erweiterung_info': ERWEITERUNG_INFO,
-        'kategorie_info': KATEGORIE_INFO,
+        "spiel_name": SPIEL_NAME,
+        "alle_rollen": ROLLEN,
+        "alle_teams": TEAMS,
+        "rollen_nach_kategorie": get_rollen_nach_kategorie(),
+        "rollen_nach_erweiterung": get_rollen_nach_erweiterung(),
+        "erweiterung_info": ERWEITERUNG_INFO,
+        "kategorie_info": KATEGORIE_INFO,
     }
 
 
@@ -53,14 +68,15 @@ def inject_globals():
 # AUDIO-HELPER - Text-to-Speech Funktionen
 # ============================================================================
 
-def generiere_erzaehler_audio(text: str, stil: str = 'normal') -> str | None:
+
+def generiere_erzaehler_audio(text: str, stil: str = "normal") -> str | None:
     """
     Generiert Audio für Erzähler-Text mittels Edge-TTS.
-    
+
     Args:
         text: Der zu sprechende Text
         stil: Der Sprechstil (normal, dramatisch, etc.)
-    
+
     Returns:
         URL-Pfad zur Audio-Datei oder None bei Fehler
     """
@@ -68,7 +84,7 @@ def generiere_erzaehler_audio(text: str, stil: str = 'normal') -> str | None:
         from audio import (
             text_zu_audio_sync,
             text_zu_audio_elevenlabs_sync,
-            elevenlabs_aktiv
+            elevenlabs_aktiv,
         )
 
         audio_path = None
@@ -80,13 +96,14 @@ def generiere_erzaehler_audio(text: str, stil: str = 'normal') -> str | None:
 
         if audio_path:
             # Konvertiere relativen Pfad zu URL-Pfad
-            url_path = '/' + audio_path.replace('\\', '/')
+            url_path = "/" + audio_path.replace("\\", "/")
             print(f"[Audio] Generated: {url_path}")
             return url_path
         return None
     except Exception as e:
         print(f"Fehler bei Audio-Generierung: {e}")
         import traceback
+
         traceback.print_exc()
         return None
 
@@ -95,28 +112,31 @@ def generiere_erzaehler_audio(text: str, stil: str = 'normal') -> str | None:
 # HTTP ROUTEN
 # ============================================================================
 
-@app.route('/')
+
+@app.route("/")
 def index():
     """Startseite mit Spielmodus-Auswahl"""
-    return render_template('index.html')
+    return render_template("index.html")
 
 
-@app.route('/rollen')
+@app.route("/rollen")
 def rollen_uebersicht():
     """Uebersicht aller Rollen"""
     kategorien = get_rollen_nach_kategorie_liste()
-    return render_template('rollen.html', kategorien=kategorien, rollen_anzahl=get_rollen_anzahl())
+    return render_template(
+        "rollen.html", kategorien=kategorien, rollen_anzahl=get_rollen_anzahl()
+    )
 
 
-@app.route('/raum/erstellen', methods=['POST'])
+@app.route("/raum/erstellen", methods=["POST"])
 def raum_erstellen():
     """Erstellt einen neuen Spielraum"""
-    modus = request.form.get('modus', 'online')
-    name = request.form.get('raum_name', 'Webwölfe Runde')
-    spieler_name = request.form.get('spieler_name', 'Spielleiter')
-    erzaehler_modus = request.form.get('erzaehler_modus', 'selbst')
-    ist_erzaehler = erzaehler_modus == 'selbst'
-    
+    modus = request.form.get("modus", "online")
+    name = request.form.get("raum_name", "Webwölfe Runde")
+    spieler_name = request.form.get("spieler_name", "Spielleiter")
+    erzaehler_modus = request.form.get("erzaehler_modus", "selbst")
+    ist_erzaehler = erzaehler_modus == "selbst"
+
     # Raum erstellen
     # Spieleranzahl wird jetzt dynamisch aus der Lobby berechnet – keine manuelle Eingabe nötig
     raum = Raum(
@@ -124,80 +144,76 @@ def raum_erstellen():
         name=name,
         modus=modus,
         spieler_anzahl=0,
-        erzaehler_modus=erzaehler_modus
+        erzaehler_modus=erzaehler_modus,
     )
     db.session.add(raum)
     db.session.flush()
-    
+
     # Ersteller als ersten Spieler hinzufuegen
     session_id = Spieler.generiere_session()
     spieler = Spieler(
         name=spieler_name[:30],
         session_id=session_id,
         raum_id=raum.id,
-        ist_erzaehler=ist_erzaehler
+        ist_erzaehler=ist_erzaehler,
     )
     db.session.add(spieler)
-    
+
     if ist_erzaehler:
         raum.erzaehler_id = spieler.id
-    
+
     db.session.commit()
-    
+
     # Session setzen
-    session['spieler_session'] = session_id
-    session['raum_code'] = raum.code
-    
-    return redirect(url_for('lobby', code=raum.code))
+    session["spieler_session"] = session_id
+    session["raum_code"] = raum.code
+
+    return redirect(url_for("lobby", code=raum.code))
 
 
-@app.route('/raum/beitreten', methods=['POST'])
+@app.route("/raum/beitreten", methods=["POST"])
 def raum_beitreten():
     """Tritt einem existierenden Raum bei"""
-    code = request.form.get('code', '').upper().strip()
-    spieler_name = request.form.get('spieler_name', 'Spieler')
-    
+    code = request.form.get("code", "").upper().strip()
+    spieler_name = request.form.get("spieler_name", "Spieler")
+
     raum = Raum.query.filter_by(code=code).first()
-    
+
     if not raum:
-        return render_template('index.html', fehler='Raum nicht gefunden!')
-    
+        return render_template("index.html", fehler="Raum nicht gefunden!")
+
     if raum.spiel_gestartet:
-        return render_template('index.html', fehler='Das Spiel hat bereits begonnen!')
-    
+        return render_template("index.html", fehler="Das Spiel hat bereits begonnen!")
+
     # Pruefen ob Name bereits vergeben
     existiert = Spieler.query.filter_by(raum_id=raum.id, name=spieler_name[:30]).first()
     if existiert:
-        return render_template('index.html', fehler='Dieser Name ist bereits vergeben!')
-    
+        return render_template("index.html", fehler="Dieser Name ist bereits vergeben!")
+
     # Spieler erstellen
     session_id = Spieler.generiere_session()
-    spieler = Spieler(
-        name=spieler_name[:30],
-        session_id=session_id,
-        raum_id=raum.id
-    )
+    spieler = Spieler(name=spieler_name[:30], session_id=session_id, raum_id=raum.id)
     db.session.add(spieler)
     db.session.commit()
-    
-    session['spieler_session'] = session_id
-    session['raum_code'] = raum.code
-    
-    return redirect(url_for('lobby', code=raum.code))
+
+    session["spieler_session"] = session_id
+    session["raum_code"] = raum.code
+
+    return redirect(url_for("lobby", code=raum.code))
 
 
-@app.route('/lobby/<code>')
+@app.route("/lobby/<code>")
 def lobby(code):
     """Lobby-Ansicht eines Raums"""
     raum = Raum.query.filter_by(code=code).first_or_404()
     spieler = hole_aktuellen_spieler()
-    
+
     if not spieler or spieler.raum_id != raum.id:
-        return redirect(url_for('index'))
-    
+        return redirect(url_for("index"))
+
     if raum.spiel_gestartet:
-        return redirect(url_for('spiel', code=code))
-    
+        return redirect(url_for("spiel", code=code))
+
     alle_spieler = Spieler.query.filter_by(raum_id=raum.id).all()
     erzaehler = next((s for s in alle_spieler if s.ist_erzaehler), None)
     spieler_ohne_erzaehler = [s for s in alle_spieler if not s.ist_erzaehler]
@@ -209,177 +225,204 @@ def lobby(code):
     fehlende_spieler = max(0, 5 - aktuelle_spielerzahl)
     rollen_vorschau_total = max(5, aktuelle_spielerzahl) + (1 if erzaehler else 0)
     rollen_vorschau = game_logic.berechne_rollen(
-        rollen_vorschau_total,
-        mit_erzaehler=bool(erzaehler)
+        rollen_vorschau_total, mit_erzaehler=bool(erzaehler)
     )
-    
-    return render_template('lobby.html', 
-                         raum=raum, 
-                         spieler=spieler,
-                         alle_spieler=alle_spieler,
-                         erzaehler=erzaehler,
-                         rollen=ROLLEN,
-                         rollen_vorschau=rollen_vorschau,
-                         rollen_vorschau_total=rollen_vorschau_total,
-                         rollen_vorschau_hat_erzaehler=bool(erzaehler),
-                         fehlende_spieler=fehlende_spieler,
-                         ist_spiel_bereit=fehlende_spieler == 0)
+
+    return render_template(
+        "lobby.html",
+        raum=raum,
+        spieler=spieler,
+        alle_spieler=alle_spieler,
+        erzaehler=erzaehler,
+        rollen=ROLLEN,
+        rollen_vorschau=rollen_vorschau,
+        rollen_vorschau_total=rollen_vorschau_total,
+        rollen_vorschau_hat_erzaehler=bool(erzaehler),
+        fehlende_spieler=fehlende_spieler,
+        ist_spiel_bereit=fehlende_spieler == 0,
+    )
 
 
-@app.route('/spiel/<code>')
+@app.route("/spiel/<code>")
 def spiel(code):
     """Hauptspielansicht"""
     raum = Raum.query.filter_by(code=code).first_or_404()
     spieler = hole_aktuellen_spieler()
-    
+
     if not spieler or spieler.raum_id != raum.id:
-        return redirect(url_for('index'))
-    
+        return redirect(url_for("index"))
+
     if not raum.spiel_gestartet:
-        return redirect(url_for('lobby', code=code))
-    
+        return redirect(url_for("lobby", code=code))
+
     alle_spieler = Spieler.query.filter_by(raum_id=raum.id).order_by(Spieler.name).all()
     lebende = [s for s in alle_spieler if s.ist_am_leben]
-    
+
     # Rolle-Info holen - SICHER: Nur eigene Rolle wird mitgegeben
     rolle_info = ROLLEN.get(spieler.rolle, {})
-    
+
     # Logs fuer Spieler - SICHER: Nur fuer den Spieler sichtbare Logs
     if spieler.ist_erzaehler:
-        logs = SpielLog.query.filter_by(raum_id=raum.id).order_by(SpielLog.zeitpunkt.desc()).limit(50).all()
+        logs = (
+            SpielLog.query.filter_by(raum_id=raum.id)
+            .order_by(SpielLog.zeitpunkt.desc())
+            .limit(50)
+            .all()
+        )
     else:
-        logs = SpielLog.query.filter(
-            SpielLog.raum_id == raum.id,
-            db.or_(
-                SpielLog.sichtbar_fuer == 'alle',
-                SpielLog.sichtbar_fuer == str(spieler.id),
-                SpielLog.sichtbar_fuer == spieler.rolle
+        logs = (
+            SpielLog.query.filter(
+                SpielLog.raum_id == raum.id,
+                db.or_(
+                    SpielLog.sichtbar_fuer == "alle",
+                    SpielLog.sichtbar_fuer == str(spieler.id),
+                    SpielLog.sichtbar_fuer == spieler.rolle,
+                ),
             )
-        ).order_by(SpielLog.zeitpunkt.desc()).limit(20).all()
-    
+            .order_by(SpielLog.zeitpunkt.desc())
+            .limit(20)
+            .all()
+        )
+
     # SICHER: Spieler-Daten werden OHNE Rollen (ausser eigene) gesendet
     sichere_spieler = []
     for s in alle_spieler:
         spieler_data = {
-            'id': s.id,
-            'name': s.name,
-            'ist_am_leben': s.ist_am_leben,
-            'ist_erzaehler': s.ist_erzaehler
+            "id": s.id,
+            "name": s.name,
+            "ist_am_leben": s.ist_am_leben,
+            "ist_erzaehler": s.ist_erzaehler,
         }
         # Rolle nur fuer sich selbst oder tote Spieler (nach Tod enthüllt)
         if s.id == spieler.id:
-            spieler_data['rolle'] = s.rolle
+            spieler_data["rolle"] = s.rolle
         elif not s.ist_am_leben:
-            spieler_data['rolle'] = s.rolle
+            spieler_data["rolle"] = s.rolle
         # Werwoelfe sehen sich gegenseitig
-        elif (game_logic.ist_werwolf_rolle(spieler.rolle) and
-              game_logic.ist_werwolf_rolle(s.rolle)):
-            spieler_data['ist_werwolf'] = True
+        elif game_logic.ist_werwolf_rolle(
+            spieler.rolle
+        ) and game_logic.ist_werwolf_rolle(s.rolle):
+            spieler_data["ist_werwolf"] = True
         sichere_spieler.append(spieler_data)
-    
+
     # Erzähler-Text für Gruppen-Modus
     erzaehler_text = None
-    if spieler.ist_erzaehler and raum.modus == 'gruppe':
+    if spieler.ist_erzaehler and raum.modus == "gruppe":
         phase_key = raum.aktuelle_phase
         if phase_key in ERZAEHLER_TEXTE:
             erzaehler_text = ERZAEHLER_TEXTE[phase_key]
-    
-    return render_template('spiel.html',
-                         raum=raum,
-                         spieler=spieler,
-                         sichere_spieler=sichere_spieler,
-                         alle_spieler=alle_spieler,
-                         lebende=lebende,
-                         rolle_info=rolle_info,
-                         logs=logs,
-                         phasen=PHASEN,
-                         erzaehler_text=erzaehler_text)
+
+    return render_template(
+        "spiel.html",
+        raum=raum,
+        spieler=spieler,
+        sichere_spieler=sichere_spieler,
+        alle_spieler=alle_spieler,
+        lebende=lebende,
+        rolle_info=rolle_info,
+        logs=logs,
+        phasen=PHASEN,
+        erzaehler_text=erzaehler_text,
+    )
 
 
 # ============================================================================
 # SITZORDNUNG API - Drag & Drop Sitzplatzwahl
 # ============================================================================
 
-@app.route('/api/sitzordnung/<code>', methods=['GET'])
+
+@app.route("/api/sitzordnung/<code>", methods=["GET"])
 def get_sitzordnung(code):
     """Gibt die aktuelle Sitzordnung zurück"""
     raum = Raum.query.filter_by(code=code).first()
     if not raum:
-        return jsonify({'success': False, 'error': 'Raum nicht gefunden'}), 404
-    
+        return jsonify({"success": False, "error": "Raum nicht gefunden"}), 404
+
     spieler = hole_aktuellen_spieler()
     if not spieler or spieler.raum_id != raum.id:
-        return jsonify({'success': False, 'error': 'Nicht autorisiert'}), 403
-    
-    alle_spieler = Spieler.query.filter_by(raum_id=raum.id, ist_erzaehler=False).order_by(Spieler.sitzplatz, Spieler.id).all()
-    
-    return jsonify({
-        'success': True,
-        'sitzordnung': [
-            {
-                'id': s.id,
-                'name': s.name,
-                'sitzplatz': s.sitzplatz if s.sitzplatz is not None else i
-            }
-            for i, s in enumerate(alle_spieler)
-        ]
-    })
+        return jsonify({"success": False, "error": "Nicht autorisiert"}), 403
+
+    alle_spieler = (
+        Spieler.query.filter_by(raum_id=raum.id, ist_erzaehler=False)
+        .order_by(Spieler.sitzplatz, Spieler.id)
+        .all()
+    )
+
+    return jsonify(
+        {
+            "success": True,
+            "sitzordnung": [
+                {
+                    "id": s.id,
+                    "name": s.name,
+                    "sitzplatz": s.sitzplatz if s.sitzplatz is not None else i,
+                }
+                for i, s in enumerate(alle_spieler)
+            ],
+        }
+    )
 
 
-@app.route('/api/sitzordnung/<code>', methods=['POST'])
+@app.route("/api/sitzordnung/<code>", methods=["POST"])
 def set_sitzordnung(code):
     """Aktualisiert die Sitzordnung"""
     raum = Raum.query.filter_by(code=code).first()
     if not raum:
-        return jsonify({'success': False, 'error': 'Raum nicht gefunden'}), 404
-    
+        return jsonify({"success": False, "error": "Raum nicht gefunden"}), 404
+
     if raum.spiel_gestartet:
-        return jsonify({'success': False, 'error': 'Spiel bereits gestartet'}), 400
-    
+        return jsonify({"success": False, "error": "Spiel bereits gestartet"}), 400
+
     spieler = hole_aktuellen_spieler()
     if not spieler or spieler.raum_id != raum.id:
-        return jsonify({'success': False, 'error': 'Nicht autorisiert'}), 403
-    
+        return jsonify({"success": False, "error": "Nicht autorisiert"}), 403
+
     data = request.get_json()
-    ordnung = data.get('ordnung', [])  # Liste von {id, sitzplatz}
-    
+    ordnung = data.get("ordnung", [])  # Liste von {id, sitzplatz}
+
     for eintrag in ordnung:
-        s = Spieler.query.get(eintrag.get('id'))
+        s = Spieler.query.get(eintrag.get("id"))
         if s and s.raum_id == raum.id:
-            s.sitzplatz = eintrag.get('sitzplatz')
-    
+            s.sitzplatz = eintrag.get("sitzplatz")
+
     db.session.commit()
-    
+
     # Broadcastet die neue Sitzordnung an alle Spieler
-    socketio.emit('sitzordnung_aktualisiert', {
-        'ordnung': ordnung
-    }, room=raum.code)
-    
-    return jsonify({'success': True})
+    socketio.emit("sitzordnung_aktualisiert", {"ordnung": ordnung}, room=raum.code)
+
+    return jsonify({"success": True})
 
 
-@app.route('/api/raum/<code>/erzaehler/random', methods=['POST'])
+@app.route("/api/raum/<code>/erzaehler/random", methods=["POST"])
 def waehle_zufaelligen_erzaehler(code):
     """Wählt einen zufälligen Erzähler aus allen Spielern des Raums."""
     raum = Raum.query.filter_by(code=code).first()
     if not raum:
-        return jsonify({'success': False, 'error': 'Raum nicht gefunden'}), 404
+        return jsonify({"success": False, "error": "Raum nicht gefunden"}), 404
 
     if raum.spiel_gestartet:
-        return jsonify({'success': False, 'error': 'Spiel bereits gestartet'}), 400
+        return jsonify({"success": False, "error": "Spiel bereits gestartet"}), 400
 
     spieler = hole_aktuellen_spieler()
     if not spieler or spieler.raum_id != raum.id:
-        return jsonify({'success': False, 'error': 'Nicht autorisiert'}), 403
+        return jsonify({"success": False, "error": "Nicht autorisiert"}), 403
 
-    if raum.erzaehler_modus != 'zufall':
-        return jsonify({'success': False, 'error': 'Zufälliger Erzähler ist für diesen Raum nicht aktiviert'}), 400
+    if raum.erzaehler_modus != "zufall":
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "error": "Zufälliger Erzähler ist für diesen Raum nicht aktiviert",
+                }
+            ),
+            400,
+        )
 
     alle_spieler = Spieler.query.filter_by(raum_id=raum.id).all()
     kandidaten = [s for s in alle_spieler if not s.ist_erzaehler]
 
     if not kandidaten:
-        return jsonify({'success': False, 'error': 'Keine Kandidaten gefunden'}), 400
+        return jsonify({"success": False, "error": "Keine Kandidaten gefunden"}), 400
 
     # Entferne bisherigen Erzähler (falls vorhanden)
     for kandidat in alle_spieler:
@@ -391,21 +434,25 @@ def waehle_zufaelligen_erzaehler(code):
     raum.erzaehler_id = erzaehler.id
     db.session.commit()
 
-    socketio.emit('erzaehler_gewaehlt', {
-        'spieler_id': erzaehler.id,
-        'name': erzaehler.name
-    }, room=raum.code)
+    socketio.emit(
+        "erzaehler_gewaehlt",
+        {"spieler_id": erzaehler.id, "name": erzaehler.name},
+        room=raum.code,
+    )
 
-    return jsonify({'success': True, 'erzaehler': {'id': erzaehler.id, 'name': erzaehler.name}})
+    return jsonify(
+        {"success": True, "erzaehler": {"id": erzaehler.id, "name": erzaehler.name}}
+    )
 
 
 # ============================================================================
 # HILFSFUNKTIONEN
 # ============================================================================
 
+
 def hole_aktuellen_spieler():
     """Holt den aktuellen Spieler basierend auf der Session"""
-    session_id = session.get('spieler_session')
+    session_id = session.get("spieler_session")
     if not session_id:
         return None
     return Spieler.query.filter_by(session_id=session_id).first()
@@ -420,54 +467,63 @@ def hole_aktuellen_spieler():
 _aktive_hinweise = {}  # raum_id -> {spieler_id: (hinweis_typ, intensitaet)}
 
 
-@app.route('/api/village/<code>')
+@app.route("/api/village/<code>")
 def api_village(code):
     """
     Rendert das Dorf server-seitig und gibt ein Bild zurück.
-    
-    SICHERHEIT: 
+
+    SICHERHEIT:
     - Keine Rollen-Information im Bild
     - Nur öffentliche Daten (Namen, lebendig/tot, Sitzplatz)
     - Hinweise werden vom Server kontrolliert
     """
     raum = Raum.query.filter_by(code=code).first()
     if not raum:
-        return jsonify({'error': 'Raum nicht gefunden'}), 404
-    
+        return jsonify({"error": "Raum nicht gefunden"}), 404
+
     spieler = hole_aktuellen_spieler()
     if not spieler or spieler.raum_id != raum.id:
-        return jsonify({'error': 'Nicht autorisiert'}), 403
-    
+        return jsonify({"error": "Nicht autorisiert"}), 403
+
     # Hole aktive Hinweise für diesen Raum
     hinweise = _aktive_hinweise.get(raum.id, {})
-    
+
     try:
         from village_renderer import render_village_for_room
+
         base64_img = render_village_for_room(raum.id, hinweise)
-        
-        return jsonify({
-            'image': base64_img,
-            'phase': raum.aktuelle_phase,
-            'runde': raum.runde,
-        })
+
+        return jsonify(
+            {
+                "image": base64_img,
+                "phase": raum.aktuelle_phase,
+                "runde": raum.runde,
+            }
+        )
     except ImportError:
         # Pillow nicht installiert - Fallback
-        return jsonify({
-            'error': 'Renderer nicht verfügbar',
-            'phase': raum.aktuelle_phase,
-            'runde': raum.runde,
-        }), 503
+        return (
+            jsonify(
+                {
+                    "error": "Renderer nicht verfügbar",
+                    "phase": raum.aktuelle_phase,
+                    "runde": raum.runde,
+                }
+            ),
+            503,
+        )
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        return jsonify({"error": str(e)}), 500
 
 
-@app.route('/api/village/test')
+@app.route("/api/village/test")
 def api_village_test():
     """Test-Endpoint für Village Rendering (nur Entwicklung)"""
     try:
         from village_renderer import generate_test_village
+
         base64_img = generate_test_village()
-        return f'''
+        return f"""
         <!DOCTYPE html>
         <html>
         <head><title>Village Test</title></head>
@@ -477,16 +533,20 @@ def api_village_test():
             <img src="{base64_img}" style="border: 3px solid #333; border-radius: 12px; max-width: 100%;">
         </body>
         </html>
-        '''
+        """
     except ImportError as e:
-        return f'<h1>Pillow nicht installiert!</h1><p>pip install pillow</p><pre>{e}</pre>', 503
+        return (
+            f"<h1>Pillow nicht installiert!</h1><p>pip install pillow</p><pre>{e}</pre>",
+            503,
+        )
 
 
 # ============================================================================
 # WEBSOCKET EVENTS - SICHER: Keine sensiblen Daten werden gebroadcastet
 # ============================================================================
 
-@socketio.on('connect')
+
+@socketio.on("connect")
 def handle_connect():
     """Spieler verbindet sich"""
     spieler = hole_aktuellen_spieler()
@@ -495,18 +555,22 @@ def handle_connect():
         if raum:
             join_room(raum.code)
             # SICHER: Nur Name und ID werden geteilt, keine Rolle
-            emit('spieler_verbunden', {
-                'spieler': {
-                    'id': spieler.id,
-                    'name': spieler.name,
-                    'ist_erzaehler': spieler.ist_erzaehler
+            emit(
+                "spieler_verbunden",
+                {
+                    "spieler": {
+                        "id": spieler.id,
+                        "name": spieler.name,
+                        "ist_erzaehler": spieler.ist_erzaehler,
+                    },
+                    "spieler_id": spieler.id,
+                    "spieler_name": spieler.name,
                 },
-                'spieler_id': spieler.id,
-                'spieler_name': spieler.name
-            }, room=raum.code)
+                room=raum.code,
+            )
 
 
-@socketio.on('disconnect')
+@socketio.on("disconnect")
 def handle_disconnect():
     """Spieler trennt Verbindung"""
     spieler = hole_aktuellen_spieler()
@@ -514,193 +578,205 @@ def handle_disconnect():
         raum = Raum.query.get(spieler.raum_id)
         if raum:
             leave_room(raum.code)
-            emit('spieler_getrennt', {
-                'spieler_id': spieler.id,
-                'spieler_name': spieler.name
-            }, room=raum.code)
+            emit(
+                "spieler_getrennt",
+                {"spieler_id": spieler.id, "spieler_name": spieler.name},
+                room=raum.code,
+            )
 
 
-@socketio.on('raum_beitreten')
+@socketio.on("raum_beitreten")
 def handle_raum_beitreten(data):
     """Spieler tritt Raum-Channel bei"""
-    code = data.get('code')
+    code = data.get("code")
     if code:
         join_room(code)
         raum = Raum.query.filter_by(code=code).first()
         if raum:
             alle_spieler = Spieler.query.filter_by(raum_id=raum.id).all()
             # SICHER: Keine Rollen werden geteilt
-            emit('spieler_liste', {
-                'spieler': [{'id': s.id, 'name': s.name, 'ist_erzaehler': s.ist_erzaehler} for s in alle_spieler]
-            }, room=code)
+            emit(
+                "spieler_liste",
+                {
+                    "spieler": [
+                        {"id": s.id, "name": s.name, "ist_erzaehler": s.ist_erzaehler}
+                        for s in alle_spieler
+                    ]
+                },
+                room=code,
+            )
 
 
-@socketio.on('spiel_starten')
+@socketio.on("spiel_starten")
 def handle_spiel_starten(data):
     """Startet das Spiel (nur Erzaehler/Ersteller)"""
     spieler = hole_aktuellen_spieler()
     if not spieler:
-        emit('fehler', {'nachricht': 'Nicht angemeldet'})
+        emit("fehler", {"nachricht": "Nicht angemeldet"})
         return
-    
+
     raum = Raum.query.get(spieler.raum_id)
     if not raum:
-        emit('fehler', {'nachricht': 'Raum nicht gefunden'})
+        emit("fehler", {"nachricht": "Raum nicht gefunden"})
         return
-    
+
     # Pruefen ob genug Spieler
     anzahl = Spieler.query.filter_by(raum_id=raum.id).count()
     if anzahl < 5:
-        emit('fehler', {'nachricht': f'Mindestens 5 Spieler benoetigt (aktuell: {anzahl})'})
+        emit(
+            "fehler",
+            {"nachricht": f"Mindestens 5 Spieler benoetigt (aktuell: {anzahl})"},
+        )
         return
-    
+
     if game_logic.starte_spiel(raum):
         # SICHER: Jeder Spieler bekommt NUR seine eigene Rolle
         alle_spieler = Spieler.query.filter_by(raum_id=raum.id).all()
-        
+
         # Spiel gestartet - alle werden zur Spielseite weitergeleitet
-        emit('spiel_gestartet', {
-            'phase': raum.aktuelle_phase,
-            'runde': raum.runde
-        }, room=raum.code)
+        emit(
+            "spiel_gestartet",
+            {"phase": raum.aktuelle_phase, "runde": raum.runde},
+            room=raum.code,
+        )
     else:
-        emit('fehler', {'nachricht': 'Spiel konnte nicht gestartet werden'})
+        emit("fehler", {"nachricht": "Spiel konnte nicht gestartet werden"})
 
 
-@socketio.on('phase_weiter')
+@socketio.on("phase_weiter")
 def handle_phase_weiter():
     """Wechselt zur naechsten Phase (Erzaehler)"""
     spieler = hole_aktuellen_spieler()
     if not spieler or not spieler.ist_erzaehler:
-        emit('fehler', {'nachricht': 'Nur der Erzaehler kann die Phase wechseln'})
+        emit("fehler", {"nachricht": "Nur der Erzaehler kann die Phase wechseln"})
         return
-    
+
     raum = Raum.query.get(spieler.raum_id)
     if not raum:
         return
-    
+
     alte_phase = raum.aktuelle_phase
     neue_phase = game_logic.naechste_phase(raum)
-    
+
     # Phase-spezifische Aktionen
     handle_phase_wechsel(raum, alte_phase, neue_phase)
-    
+
     # Erzähler-Text für Gruppen-Modus
     erzaehler_text = None
-    if raum.modus == 'gruppe' and neue_phase in ERZAEHLER_TEXTE:
+    if raum.modus == "gruppe" and neue_phase in ERZAEHLER_TEXTE:
         erzaehler_text = ERZAEHLER_TEXTE[neue_phase]
-    
+
     # Online-Modus: Automatische Erzählung mit Audio senden
-    if raum.modus == 'online' and neue_phase in ERZAEHLER_TEXTE:
+    if raum.modus == "online" and neue_phase in ERZAEHLER_TEXTE:
         erzaehler_info = ERZAEHLER_TEXTE[neue_phase]
-        erzaehlung_text = erzaehler_info.get('text', '')
-        
+        erzaehlung_text = erzaehler_info.get("text", "")
+
         # Generiere Audio für die Erzählung
         audio_path = None
         if erzaehlung_text:
             # Bestimme Stil basierend auf Phase
-            stil = 'normal'
-            if 'werwolf' in neue_phase.lower():
-                stil = 'dramatisch'
-            elif 'tot' in erzaehlung_text.lower() or 'stirbt' in erzaehlung_text.lower():
-                stil = 'dramatisch'
-            
+            stil = "normal"
+            if "werwolf" in neue_phase.lower():
+                stil = "dramatisch"
+            elif (
+                "tot" in erzaehlung_text.lower() or "stirbt" in erzaehlung_text.lower()
+            ):
+                stil = "dramatisch"
+
             audio_path = generiere_erzaehler_audio(erzaehlung_text, stil=stil)
-        
-        emit('erzaehlung', {
-            'text': erzaehlung_text,
-            'audio': audio_path
-        }, room=raum.code)
-    
-    emit('phase_geaendert', {
-        'phase': neue_phase,
-        'runde': raum.runde,
-        'alte_phase': alte_phase,
-        'erzaehler_text': erzaehler_text
-    }, room=raum.code)
+
+        emit(
+            "erzaehlung", {"text": erzaehlung_text, "audio": audio_path}, room=raum.code
+        )
+
+    emit(
+        "phase_geaendert",
+        {
+            "phase": neue_phase,
+            "runde": raum.runde,
+            "alte_phase": alte_phase,
+            "erzaehler_text": erzaehler_text,
+        },
+        room=raum.code,
+    )
 
 
-@socketio.on('aktion_ausfuehren')
+@socketio.on("aktion_ausfuehren")
 def handle_aktion(data):
     """Fuehrt eine Spielaktion aus"""
     spieler = hole_aktuellen_spieler()
     if not spieler:
-        emit('fehler', {'nachricht': 'Nicht angemeldet'})
+        emit("fehler", {"nachricht": "Nicht angemeldet"})
         return
-    
+
     raum = Raum.query.get(spieler.raum_id)
     if not raum:
         return
-    
-    aktion_typ = data.get('aktion')
-    ziel_id = data.get('ziel_id')
-    
+
+    aktion_typ = data.get("aktion")
+    ziel_id = data.get("ziel_id")
+
     # Validierung
-    if not spieler.ist_am_leben and aktion_typ != 'jaeger_schuss':
-        emit('fehler', {'nachricht': 'Du bist tot und kannst nicht handeln'})
+    if not spieler.ist_am_leben and aktion_typ != "jaeger_schuss":
+        emit("fehler", {"nachricht": "Du bist tot und kannst nicht handeln"})
         return
-    
+
     # Aktion basierend auf Phase und Rolle verarbeiten
     erfolg = verarbeite_aktion(spieler, raum, aktion_typ, ziel_id)
-    
+
     if erfolg:
-        emit('aktion_bestaetigt', {'aktion': aktion_typ})
-        
+        emit("aktion_bestaetigt", {"aktion": aktion_typ})
+
         # Pruefen ob alle fertig sind
         pruefe_phase_abschluss(raum)
     else:
-        emit('fehler', {'nachricht': 'Aktion konnte nicht ausgefuehrt werden'})
+        emit("fehler", {"nachricht": "Aktion konnte nicht ausgefuehrt werden"})
 
 
-@socketio.on('chat_nachricht')
+@socketio.on("chat_nachricht")
 def handle_chat(data):
     """Verarbeitet Chat-Nachrichten"""
     spieler = hole_aktuellen_spieler()
     if not spieler:
         return
-    
+
     raum = Raum.query.get(spieler.raum_id)
     if not raum:
         return
-    
-    nachricht = data.get('nachricht', '')[:500]
-    
+
+    nachricht = data.get("nachricht", "")[:500]
+
     # SICHER: Keine sensiblen Daten im Chat
     if not spieler.ist_am_leben:
         # Tote chatten nur mit Toten
-        emit('chat_tot', {
-            'von': spieler.name,
-            'nachricht': nachricht
-        }, room=raum.code)
+        emit("chat_tot", {"von": spieler.name, "nachricht": nachricht}, room=raum.code)
     else:
-        emit('chat', {
-            'von': spieler.name,
-            'nachricht': nachricht
-        }, room=raum.code)
+        emit("chat", {"von": spieler.name, "nachricht": nachricht}, room=raum.code)
 
 
-@socketio.on('navigiere_zur_lobby')
+@socketio.on("navigiere_zur_lobby")
 def handle_navigiere_lobby():
     """Sendet Navigation zur Startseite"""
-    emit('gehe_zu_startseite')
+    emit("gehe_zu_startseite")
 
 
-@socketio.on('navigiere')
+@socketio.on("navigiere")
 def handle_navigiere(data):
     """Sendet Navigation zu angegebenem Ziel"""
-    ziel = data.get('ziel', '/')
-    emit('navigiere', {'ziel': ziel})
+    ziel = data.get("ziel", "/")
+    emit("navigiere", {"ziel": ziel})
 
 
 # ============================================================================
 # HINWEIS-SYSTEM - Server-kontrollierte synchronisierte Hinweise
 # ============================================================================
 
-@socketio.on('hinweis_senden')
+
+@socketio.on("hinweis_senden")
 def handle_hinweis_senden(data):
     """
     Verarbeitet Hinweis-Anfragen (z.B. Selbstmörder macht sich verdächtig)
-    
+
     Der Server:
     1. Validiert, dass der Spieler den Hinweis senden darf
     2. Broadcastet den Hinweis an ALLE Spieler im Raum gleichzeitig
@@ -708,62 +784,67 @@ def handle_hinweis_senden(data):
     """
     from models import SPEZIAL_HINWEISE
     import random
-    
+
     spieler = hole_aktuellen_spieler()
     if not spieler or not spieler.raum_id:
         return
-    
+
     raum = Raum.query.get(spieler.raum_id)
     if not raum or not raum.spiel_gestartet:
         return
-    
-    hinweis_typ = data.get('hintTyp')
-    selbst_ausgeloest = data.get('selbst_ausgeloest', False)
-    
+
+    hinweis_typ = data.get("hintTyp")
+    selbst_ausgeloest = data.get("selbst_ausgeloest", False)
+
     # Validierung: Darf dieser Spieler Hinweise senden?
     if selbst_ausgeloest:
         # Nur bestimmte Rollen dürfen sich selbst verdächtig machen
         spezial = SPEZIAL_HINWEISE.get(spieler.rolle)
-        if not spezial or not spezial.get('kann_hinweis_senden'):
-            emit('fehler', {'nachricht': 'Du kannst keine Hinweise senden!'})
+        if not spezial or not spezial.get("kann_hinweis_senden"):
+            emit("fehler", {"nachricht": "Du kannst keine Hinweise senden!"})
             return
-        
+
         # Prüfe verfügbare Hinweise
-        if hinweis_typ not in spezial.get('verfuegbare_hinweise', []):
-            hinweis_typ = random.choice(spezial['verfuegbare_hinweise'])
-    
+        if hinweis_typ not in spezial.get("verfuegbare_hinweise", []):
+            hinweis_typ = random.choice(spezial["verfuegbare_hinweise"])
+
     # Speichere Hinweis für Village-Rendering
     if raum.id not in _aktive_hinweise:
         _aktive_hinweise[raum.id] = {}
-    
+
     # Intensität: selbst-ausgelöst = stark, automatisch = variabel
     intensitaet = 0.8 if selbst_ausgeloest else random.uniform(0.4, 0.7)
     _aktive_hinweise[raum.id][spieler.id] = (hinweis_typ, intensitaet)
-    
+
     # Broadcaste Hinweis an ALLE Spieler im Raum (synchronisiert!)
-    socketio.emit('hinweis_zeigen', {
-        'spielerId': spieler.id,
-        'spielerName': spieler.name,
-        'hintTyp': hinweis_typ,
-        'timestamp': datetime.utcnow().isoformat(),
-    }, room=raum.code)
-    
+    socketio.emit(
+        "hinweis_zeigen",
+        {
+            "spielerId": spieler.id,
+            "spielerName": spieler.name,
+            "hintTyp": hinweis_typ,
+            "timestamp": datetime.utcnow().isoformat(),
+        },
+        room=raum.code,
+    )
+
     # Log für Erzähler
     log = SpielLog(
         raum_id=raum.id,
-        nachricht=f'[HINWEIS] {spieler.name} zeigte: {hinweis_typ}',
-        sichtbar_fuer='erzaehler'
+        nachricht=f"[HINWEIS] {spieler.name} zeigte: {hinweis_typ}",
+        sichtbar_fuer="erzaehler",
     )
     db.session.add(log)
     db.session.commit()
-    
+
     # Lösche Hinweis nach 5 Sekunden aus dem Cache
     def clear_hint():
         import time
+
         time.sleep(5)
         if raum.id in _aktive_hinweise and spieler.id in _aktive_hinweise[raum.id]:
             del _aktive_hinweise[raum.id][spieler.id]
-    
+
     # In Background ausführen (eventlet-kompatibel)
     socketio.start_background_task(clear_hint)
 
@@ -772,79 +853,83 @@ def generiere_zufalls_hinweis(raum_id: int):
     """
     Generiert zufällige Hinweise basierend auf Rollen-Teams.
     Wird vom Server aufgerufen, z.B. bei Phasenwechsel.
-    
+
     WICHTIG: Diese Hinweise werden vom SERVER gewürfelt und
     an ALLE Spieler gleichzeitig gesendet!
     """
     from models import HINWEIS_CHANCEN
     import random
-    
+
     raum = Raum.query.get(raum_id)
     if not raum:
         return
-    
+
     spieler_liste = Spieler.query.filter_by(
-        raum_id=raum_id, 
-        ist_am_leben=True,
-        ist_erzaehler=False
+        raum_id=raum_id, ist_am_leben=True, ist_erzaehler=False
     ).all()
-    
+
     for spieler in spieler_liste:
         rolle_info = ROLLEN.get(spieler.rolle, {})
-        team = rolle_info.get('team', 'dorf')
-        
-        config = HINWEIS_CHANCEN.get(team, HINWEIS_CHANCEN['dorf'])
-        
+        team = rolle_info.get("team", "dorf")
+
+        config = HINWEIS_CHANCEN.get(team, HINWEIS_CHANCEN["dorf"])
+
         # Würfle ob Hinweis generiert wird
-        if random.random() > config['basis_chance']:
+        if random.random() > config["basis_chance"]:
             continue
-        
+
         # Wähle zufälligen Hinweis
-        hinweis_typ = random.choice(config['hinweise'])
+        hinweis_typ = random.choice(config["hinweise"])
         intensitaet = random.uniform(0.3, 0.6)
-        
+
         # Speichere für Rendering
         if raum_id not in _aktive_hinweise:
             _aktive_hinweise[raum_id] = {}
         _aktive_hinweise[raum_id][spieler.id] = (hinweis_typ, intensitaet)
-        
+
         # Broadcaste an alle
-        socketio.emit('hinweis_zeigen', {
-            'spielerId': spieler.id,
-            'spielerName': spieler.name,
-            'hintTyp': hinweis_typ,
-            'timestamp': datetime.utcnow().isoformat(),
-        }, room=raum.code)
+        socketio.emit(
+            "hinweis_zeigen",
+            {
+                "spielerId": spieler.id,
+                "spielerName": spieler.name,
+                "hintTyp": hinweis_typ,
+                "timestamp": datetime.utcnow().isoformat(),
+            },
+            room=raum.code,
+        )
 
 
 # ============================================================================
 # SPIELLOGIK HELFER
 # ============================================================================
 
+
 def verarbeite_aktion(spieler, raum, aktion_typ, ziel_id):
     """Verarbeitet eine Spielaktion"""
-    
-    if aktion_typ == 'werwolf_wahl':
-        if (not game_logic.ist_werwolf_rolle(spieler.rolle) or
-                raum.aktuelle_phase != 'werwolf_phase'):
+
+    if aktion_typ == "werwolf_wahl":
+        if (
+            not game_logic.ist_werwolf_rolle(spieler.rolle)
+            or raum.aktuelle_phase != "werwolf_phase"
+        ):
             return False
-        if game_logic.hat_spieler_gewaehlt(spieler, raum, 'werwolf_phase'):
+        if game_logic.hat_spieler_gewaehlt(spieler, raum, "werwolf_phase"):
             return False
         game_logic.registriere_aktion(
-            raum.id, raum.runde, 'werwolf_phase', 
-            'werwolf_wahl', spieler.id, ziel_id
+            raum.id, raum.runde, "werwolf_phase", "werwolf_wahl", spieler.id, ziel_id
         )
         return True
-    
-    elif aktion_typ == 'seherin_sehen':
-        if spieler.rolle != 'Seherin' or raum.aktuelle_phase != 'seherin_phase':
+
+    elif aktion_typ == "seherin_sehen":
+        if spieler.rolle != "Seherin" or raum.aktuelle_phase != "seherin_phase":
             return False
         ziel = Spieler.query.get(ziel_id)
         if ziel:
             # SICHER: Ergebnis nur an anfragenden Spieler senden
             from roles import RoleRegistry
             from roles.enums import SichtTyp
-            
+
             ziel_rolle = RoleRegistry.get(ziel.rolle)
             if ziel_rolle:
                 sicht = ziel_rolle.sichtbar_als_fuer("Seherin")
@@ -852,162 +937,178 @@ def verarbeite_aktion(spieler, raum, aktion_typ, ziel_id):
             else:
                 sicht = SichtTyp.DORF
                 rollen_name = ziel.rolle or "Unbekannt"
-            
+
             ist_werwolf = sicht == SichtTyp.WERWOLF
-            socketio.emit('seherin_ergebnis', {
-                'ziel_name': ziel.name,
-                'ist_werwolf': ist_werwolf,
-                'rolle': rollen_name
-            }, room=request.sid)
+            socketio.emit(
+                "seherin_ergebnis",
+                {
+                    "ziel_name": ziel.name,
+                    "ist_werwolf": ist_werwolf,
+                    "rolle": rollen_name,
+                },
+                room=request.sid,
+            )
             game_logic.registriere_aktion(
-                raum.id, raum.runde, 'seherin_phase',
-                'sehen', spieler.id, ziel_id
+                raum.id, raum.runde, "seherin_phase", "sehen", spieler.id, ziel_id
             )
             return True
         return False
-    
-    elif aktion_typ == 'heiler_schuetzen':
-        if spieler.rolle != 'Heiler' or raum.aktuelle_phase != 'heiler_phase':
+
+    elif aktion_typ == "heiler_schuetzen":
+        if spieler.rolle != "Heiler" or raum.aktuelle_phase != "heiler_phase":
             return False
         # Nicht zweimal denselben schuetzen
         if spieler.heiler_geschuetzt == ziel_id:
-            emit('fehler', {'nachricht': 'Du kannst nicht zweimal hintereinander denselben Spieler schuetzen!'})
+            emit(
+                "fehler",
+                {
+                    "nachricht": "Du kannst nicht zweimal hintereinander denselben Spieler schuetzen!"
+                },
+            )
             return False
         spieler.heiler_geschuetzt = ziel_id
         ziel = Spieler.query.get(ziel_id)
         if ziel:
             ziel.ist_beschuetzt = True
         game_logic.registriere_aktion(
-            raum.id, raum.runde, 'heiler_phase',
-            'schuetzen', spieler.id, ziel_id
+            raum.id, raum.runde, "heiler_phase", "schuetzen", spieler.id, ziel_id
         )
         db.session.commit()
         return True
-    
-    elif aktion_typ == 'hexe_heilen':
-        if spieler.rolle != 'Hexe' or raum.aktuelle_phase != 'hexe_phase':
+
+    elif aktion_typ == "hexe_heilen":
+        if spieler.rolle != "Hexe" or raum.aktuelle_phase != "hexe_phase":
             return False
         if not spieler.hexe_heiltrank:
             return False
         spieler.hexe_heiltrank = False
         game_logic.registriere_aktion(
-            raum.id, raum.runde, 'hexe_phase',
-            'heilen', spieler.id, ziel_id
+            raum.id, raum.runde, "hexe_phase", "heilen", spieler.id, ziel_id
         )
         db.session.commit()
         return True
-    
-    elif aktion_typ == 'hexe_toeten':
-        if spieler.rolle != 'Hexe' or raum.aktuelle_phase != 'hexe_phase':
+
+    elif aktion_typ == "hexe_toeten":
+        if spieler.rolle != "Hexe" or raum.aktuelle_phase != "hexe_phase":
             return False
         if not spieler.hexe_gifttrank:
             return False
         spieler.hexe_gifttrank = False
         game_logic.registriere_aktion(
-            raum.id, raum.runde, 'hexe_phase',
-            'vergiften', spieler.id, ziel_id
+            raum.id, raum.runde, "hexe_phase", "vergiften", spieler.id, ziel_id
         )
         db.session.commit()
         return True
-    
-    elif aktion_typ == 'armor_verlieben':
-        if spieler.rolle != 'Amor' or raum.aktuelle_phase != 'armor_phase':
+
+    elif aktion_typ == "armor_verlieben":
+        if spieler.rolle != "Amor" or raum.aktuelle_phase != "armor_phase":
             return False
         if not spieler.armor_verliebt:
             return False
-        
+
         ziel_ids = ziel_id if isinstance(ziel_id, list) else [ziel_id]
         if len(ziel_ids) != 2:
             return False
-        
+
         spieler1 = Spieler.query.get(ziel_ids[0])
         spieler2 = Spieler.query.get(ziel_ids[1])
-        
+
         if spieler1 and spieler2:
             spieler1.verliebt_mit_id = spieler2.id
             spieler2.verliebt_mit_id = spieler1.id
             spieler.armor_verliebt = False
             db.session.commit()
-            
+
             # SICHER: Verliebte werden privat informiert
             game_logic.log_eintrag(
                 raum.id,
                 f"Du bist verliebt in {spieler2.name}!",
-                sichtbar_fuer=str(spieler1.id)
+                sichtbar_fuer=str(spieler1.id),
             )
             game_logic.log_eintrag(
                 raum.id,
                 f"Du bist verliebt in {spieler1.name}!",
-                sichtbar_fuer=str(spieler2.id)
+                sichtbar_fuer=str(spieler2.id),
             )
             return True
         return False
-    
-    elif aktion_typ == 'tag_wahl':
-        if raum.aktuelle_phase != 'abstimmung':
+
+    elif aktion_typ == "tag_wahl":
+        if raum.aktuelle_phase != "abstimmung":
             return False
-        if game_logic.hat_spieler_gewaehlt(spieler, raum, 'abstimmung'):
+        if game_logic.hat_spieler_gewaehlt(spieler, raum, "abstimmung"):
             return False
         game_logic.registriere_aktion(
-            raum.id, raum.runde, 'abstimmung',
-            'tag_wahl', spieler.id, ziel_id
+            raum.id, raum.runde, "abstimmung", "tag_wahl", spieler.id, ziel_id
         )
         return True
-    
-    elif aktion_typ == 'jaeger_schuss':
-        if spieler.rolle != 'Jäger' or not spieler.jaeger_schuss:
+
+    elif aktion_typ == "jaeger_schuss":
+        if spieler.rolle != "Jäger" or not spieler.jaeger_schuss:
             return False
         spieler.jaeger_schuss = False
         ziel = Spieler.query.get(ziel_id)
         if ziel:
-            ergebnis = game_logic.toete_spieler(ziel, 'jaeger')
+            ergebnis = game_logic.toete_spieler(ziel, "jaeger")
             # SICHER: Nur Name wird geteilt, Rolle erst nach Tod
-            emit('spieler_gestorben', {
-                'spieler_id': ziel.id,
-                'spieler_name': ziel.name,
-                'todesart': 'jaeger',
-                'rolle': ziel.rolle  # Rolle wird nach Tod enthuellt
-            }, room=raum.code)
+            emit(
+                "spieler_gestorben",
+                {
+                    "spieler_id": ziel.id,
+                    "spieler_name": ziel.name,
+                    "todesart": "jaeger",
+                    "rolle": ziel.rolle,  # Rolle wird nach Tod enthuellt
+                },
+                room=raum.code,
+            )
             db.session.commit()
             return True
         return False
-    
+
     return False
 
 
 def handle_phase_wechsel(raum, alte_phase, neue_phase):
     """Behandelt Phasenwechsel-Logik"""
-    
+
     # Heiler-Schutz zuruecksetzen am Nachtende
-    if alte_phase == 'heiler_phase':
+    if alte_phase == "heiler_phase":
         pass  # Schutz bleibt bis Nacht-Ende
-    
-    if alte_phase == 'werwolf_phase':
+
+    if alte_phase == "werwolf_phase":
         # Werwolf-Opfer ermitteln
         ergebnis = game_logic.werwolf_abstimmung(raum)
-        if ergebnis and 'opfer_id' in ergebnis:
+        if ergebnis and "opfer_id" in ergebnis:
             # SICHER: Nur an Hexe senden (private Nachricht)
-            hexe = Spieler.query.filter_by(raum_id=raum.id, rolle='Hexe', ist_am_leben=True).first()
+            hexe = Spieler.query.filter_by(
+                raum_id=raum.id, rolle="Hexe", ist_am_leben=True
+            ).first()
             if hexe:
                 # Speichere in Session oder Temp-Daten fuer Hexe
                 pass
-    
-    elif alte_phase == 'hexe_phase':
+
+    elif alte_phase == "hexe_phase":
         # Nacht-Ende: Tote bekannt geben
         werwolf_opfer = SpielAktion.query.filter_by(
-            raum_id=raum.id, runde=raum.runde, phase='werwolf_phase', aktion_typ='werwolf_wahl'
+            raum_id=raum.id,
+            runde=raum.runde,
+            phase="werwolf_phase",
+            aktion_typ="werwolf_wahl",
         ).first()
-        
+
         geheilt = SpielAktion.query.filter_by(
-            raum_id=raum.id, runde=raum.runde, phase='hexe_phase', aktion_typ='heilen'
+            raum_id=raum.id, runde=raum.runde, phase="hexe_phase", aktion_typ="heilen"
         ).first()
-        
+
         vergiftet = SpielAktion.query.filter_by(
-            raum_id=raum.id, runde=raum.runde, phase='hexe_phase', aktion_typ='vergiften'
+            raum_id=raum.id,
+            runde=raum.runde,
+            phase="hexe_phase",
+            aktion_typ="vergiften",
         ).first()
-        
+
         tote = []
-        
+
         # Werwolf-Opfer (wenn nicht geheilt oder geschuetzt)
         if werwolf_opfer and werwolf_opfer.ziel_spieler_id:
             opfer = Spieler.query.get(werwolf_opfer.ziel_spieler_id)
@@ -1019,99 +1120,120 @@ def handle_phase_wechsel(raum, alte_phase, neue_phase):
                 elif opfer.ist_beschuetzt:
                     pass  # Geschuetzt!
                 else:
-                    game_logic.toete_spieler(opfer, 'werwolf')
-                    tote.append({'name': opfer.name, 'rolle': opfer.rolle, 'todesart': 'werwolf'})
-        
+                    game_logic.toete_spieler(opfer, "werwolf")
+                    tote.append(
+                        {
+                            "name": opfer.name,
+                            "rolle": opfer.rolle,
+                            "todesart": "werwolf",
+                        }
+                    )
+
         # Hexen-Gift-Opfer
         if vergiftet and vergiftet.ziel_spieler_id:
             opfer = Spieler.query.get(vergiftet.ziel_spieler_id)
             if opfer and opfer.ist_am_leben:
-                game_logic.toete_spieler(opfer, 'hexe')
-                tote.append({'name': opfer.name, 'rolle': opfer.rolle, 'todesart': 'hexe'})
-        
+                game_logic.toete_spieler(opfer, "hexe")
+                tote.append(
+                    {"name": opfer.name, "rolle": opfer.rolle, "todesart": "hexe"}
+                )
+
         # Heiler-Schutz zuruecksetzen
         for s in Spieler.query.filter_by(raum_id=raum.id).all():
             s.ist_beschuetzt = False
         db.session.commit()
-        
+
         if tote:
-            socketio.emit('nacht_ergebnis', {'tote': tote}, room=raum.code)
+            socketio.emit("nacht_ergebnis", {"tote": tote}, room=raum.code)
         else:
-            socketio.emit('nacht_ergebnis', {'tote': [], 'nachricht': 'Niemand ist in der Nacht gestorben.'}, room=raum.code)
-        
+            socketio.emit(
+                "nacht_ergebnis",
+                {"tote": [], "nachricht": "Niemand ist in der Nacht gestorben."},
+                room=raum.code,
+            )
+
         # Spielende pruefen
         ende = game_logic.pruefe_spielende(raum)
         if ende:
-            raum.aktuelle_phase = 'spiel_ende'
+            raum.aktuelle_phase = "spiel_ende"
             db.session.commit()
-            socketio.emit('spiel_ende', ende, room=raum.code)
-    
-    elif alte_phase == 'abstimmung':
+            socketio.emit("spiel_ende", ende, room=raum.code)
+
+    elif alte_phase == "abstimmung":
         # Tag-Abstimmung auswerten
         ergebnis = game_logic.tag_abstimmung(raum)
-        
+
         if ergebnis:
-            if ergebnis.get('kein_opfer'):
-                socketio.emit('abstimmung_ergebnis', {
-                    'kein_opfer': True,
-                    'nachricht': ergebnis.get('nachricht')
-                }, room=raum.code)
+            if ergebnis.get("kein_opfer"):
+                socketio.emit(
+                    "abstimmung_ergebnis",
+                    {"kein_opfer": True, "nachricht": ergebnis.get("nachricht")},
+                    room=raum.code,
+                )
             else:
-                opfer = Spieler.query.get(ergebnis['opfer_id'])
+                opfer = Spieler.query.get(ergebnis["opfer_id"])
                 if opfer:
-                    tod_ergebnis = game_logic.toete_spieler(opfer, 'abstimmung')
-                    socketio.emit('abstimmung_ergebnis', {
-                        'opfer_name': ergebnis['opfer_name'],
-                        'opfer_rolle': ergebnis['opfer_rolle'],
-                        'stimmen': ergebnis['stimmen'],
-                        'jaeger_aktiv': 'jaeger_schuss' in tod_ergebnis.get('folge_aktionen', [])
-                    }, room=raum.code)
-                    
+                    tod_ergebnis = game_logic.toete_spieler(opfer, "abstimmung")
+                    socketio.emit(
+                        "abstimmung_ergebnis",
+                        {
+                            "opfer_name": ergebnis["opfer_name"],
+                            "opfer_rolle": ergebnis["opfer_rolle"],
+                            "stimmen": ergebnis["stimmen"],
+                            "jaeger_aktiv": "jaeger_schuss"
+                            in tod_ergebnis.get("folge_aktionen", []),
+                        },
+                        room=raum.code,
+                    )
+
                     # Jaeger-Phase einschalten wenn noetig
-                    if 'jaeger_schuss' in tod_ergebnis.get('folge_aktionen', []):
-                        raum.aktuelle_phase = 'jaeger_phase'
+                    if "jaeger_schuss" in tod_ergebnis.get("folge_aktionen", []):
+                        raum.aktuelle_phase = "jaeger_phase"
                         db.session.commit()
-        
+
         # Spielende pruefen
         ende = game_logic.pruefe_spielende(raum)
         if ende:
-            raum.aktuelle_phase = 'spiel_ende'
+            raum.aktuelle_phase = "spiel_ende"
             db.session.commit()
-            socketio.emit('spiel_ende', ende, room=raum.code)
+            socketio.emit("spiel_ende", ende, room=raum.code)
 
 
 def pruefe_phase_abschluss(raum):
     """Prueft ob die aktuelle Phase abgeschlossen werden kann"""
-    
-    if raum.aktuelle_phase == 'werwolf_phase':
-        werwoelfe = game_logic.hole_spieler_fuer_rolle(raum, 'Werwolf')
-        if all(game_logic.hat_spieler_gewaehlt(w, raum, 'werwolf_phase') for w in werwoelfe):
-            socketio.emit('phase_bereit', {'phase': 'werwolf_phase'}, room=raum.code)
-    
-    elif raum.aktuelle_phase == 'abstimmung':
+
+    if raum.aktuelle_phase == "werwolf_phase":
+        werwoelfe = game_logic.hole_spieler_fuer_rolle(raum, "Werwolf")
+        if all(
+            game_logic.hat_spieler_gewaehlt(w, raum, "werwolf_phase") for w in werwoelfe
+        ):
+            socketio.emit("phase_bereit", {"phase": "werwolf_phase"}, room=raum.code)
+
+    elif raum.aktuelle_phase == "abstimmung":
         lebende = game_logic.hole_lebende_spieler(raum)
-        if all(game_logic.hat_spieler_gewaehlt(s, raum, 'abstimmung') for s in lebende):
-            socketio.emit('phase_bereit', {'phase': 'abstimmung'}, room=raum.code)
+        if all(game_logic.hat_spieler_gewaehlt(s, raum, "abstimmung") for s in lebende):
+            socketio.emit("phase_bereit", {"phase": "abstimmung"}, room=raum.code)
 
 
 # ============================================================================
 # ERROR HANDLER
 # ============================================================================
 
+
 @app.errorhandler(404)
 def nicht_gefunden(e):
-    return render_template('404.html'), 404
+    return render_template("404.html"), 404
 
 
 @app.errorhandler(500)
 def server_fehler(e):
-    return render_template('fehler.html'), 500
+    return render_template("fehler.html"), 500
 
 
 # ============================================================================
 # MAIN
 # ============================================================================
 
-if __name__ == '__main__':
-    port = int(os.environ.get('PORT', '8888'))
-    socketio.run(app, debug=True, host='0.0.0.0', port=port)
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", "8888"))
+    socketio.run(app, debug=True, host="0.0.0.0", port=port)

--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ import game_logic
 import secrets
 import os
 import asyncio
+import random
 from datetime import datetime
 
 # App Konfiguration
@@ -64,8 +65,19 @@ def generiere_erzaehler_audio(text: str, stil: str = 'normal') -> str | None:
         URL-Pfad zur Audio-Datei oder None bei Fehler
     """
     try:
-        from audio import text_zu_audio_sync
-        audio_path = text_zu_audio_sync(text, stil=stil)
+        from audio import (
+            text_zu_audio_sync,
+            text_zu_audio_elevenlabs_sync,
+            elevenlabs_aktiv
+        )
+
+        audio_path = None
+        if elevenlabs_aktiv():
+            audio_path = text_zu_audio_elevenlabs_sync(text, stil=stil)
+
+        if not audio_path:
+            audio_path = text_zu_audio_sync(text, stil=stil)
+
         if audio_path:
             # Konvertiere relativen Pfad zu URL-Pfad
             url_path = '/' + audio_path.replace('\\', '/')
@@ -101,17 +113,18 @@ def raum_erstellen():
     """Erstellt einen neuen Spielraum"""
     modus = request.form.get('modus', 'online')
     name = request.form.get('raum_name', 'Webwölfe Runde')
-    spieler_anzahl = int(request.form.get('spieler_anzahl', 8))
     spieler_name = request.form.get('spieler_name', 'Spielleiter')
-    ist_erzaehler = request.form.get('ist_erzaehler') == 'on'
+    erzaehler_modus = request.form.get('erzaehler_modus', 'selbst')
+    ist_erzaehler = erzaehler_modus == 'selbst'
     
     # Raum erstellen
-    # Support games from 5 to 10000 players (for massive events)
+    # Spieleranzahl wird jetzt dynamisch aus der Lobby berechnet – keine manuelle Eingabe nötig
     raum = Raum(
         code=Raum.generiere_code(),
-            name=name,
+        name=name,
         modus=modus,
-        spieler_anzahl=max(5, min(10000, spieler_anzahl))
+        spieler_anzahl=0,
+        erzaehler_modus=erzaehler_modus
     )
     db.session.add(raum)
     db.session.flush()
@@ -188,8 +201,13 @@ def lobby(code):
     alle_spieler = Spieler.query.filter_by(raum_id=raum.id).all()
     erzaehler = next((s for s in alle_spieler if s.ist_erzaehler), None)
     spieler_ohne_erzaehler = [s for s in alle_spieler if not s.ist_erzaehler]
-    fehlende_spieler = max(0, raum.spieler_anzahl - len(spieler_ohne_erzaehler))
-    rollen_vorschau_total = raum.spieler_anzahl + (1 if erzaehler else 0)
+    aktuelle_spielerzahl = len(spieler_ohne_erzaehler)
+    ziel_spielerzahl = max(5, aktuelle_spielerzahl)
+    raum.spieler_anzahl = ziel_spielerzahl
+    db.session.commit()
+
+    fehlende_spieler = max(0, 5 - aktuelle_spielerzahl)
+    rollen_vorschau_total = max(5, aktuelle_spielerzahl) + (1 if erzaehler else 0)
     rollen_vorschau = game_logic.berechne_rollen(
         rollen_vorschau_total,
         mit_erzaehler=bool(erzaehler)
@@ -199,6 +217,7 @@ def lobby(code):
                          raum=raum, 
                          spieler=spieler,
                          alle_spieler=alle_spieler,
+                         erzaehler=erzaehler,
                          rollen=ROLLEN,
                          rollen_vorschau=rollen_vorschau,
                          rollen_vorschau_total=rollen_vorschau_total,
@@ -337,6 +356,47 @@ def set_sitzordnung(code):
     }, room=raum.code)
     
     return jsonify({'success': True})
+
+
+@app.route('/api/raum/<code>/erzaehler/random', methods=['POST'])
+def waehle_zufaelligen_erzaehler(code):
+    """Wählt einen zufälligen Erzähler aus allen Spielern des Raums."""
+    raum = Raum.query.filter_by(code=code).first()
+    if not raum:
+        return jsonify({'success': False, 'error': 'Raum nicht gefunden'}), 404
+
+    if raum.spiel_gestartet:
+        return jsonify({'success': False, 'error': 'Spiel bereits gestartet'}), 400
+
+    spieler = hole_aktuellen_spieler()
+    if not spieler or spieler.raum_id != raum.id:
+        return jsonify({'success': False, 'error': 'Nicht autorisiert'}), 403
+
+    if raum.erzaehler_modus != 'zufall':
+        return jsonify({'success': False, 'error': 'Zufälliger Erzähler ist für diesen Raum nicht aktiviert'}), 400
+
+    alle_spieler = Spieler.query.filter_by(raum_id=raum.id).all()
+    kandidaten = [s for s in alle_spieler if not s.ist_erzaehler]
+
+    if not kandidaten:
+        return jsonify({'success': False, 'error': 'Keine Kandidaten gefunden'}), 400
+
+    # Entferne bisherigen Erzähler (falls vorhanden)
+    for kandidat in alle_spieler:
+        if kandidat.ist_erzaehler:
+            kandidat.ist_erzaehler = False
+
+    erzaehler = random.choice(kandidaten)
+    erzaehler.ist_erzaehler = True
+    raum.erzaehler_id = erzaehler.id
+    db.session.commit()
+
+    socketio.emit('erzaehler_gewaehlt', {
+        'spieler_id': erzaehler.id,
+        'name': erzaehler.name
+    }, room=raum.code)
+
+    return jsonify({'success': True, 'erzaehler': {'id': erzaehler.id, 'name': erzaehler.name}})
 
 
 # ============================================================================

--- a/app.py
+++ b/app.py
@@ -23,7 +23,6 @@ from roles import get_rollen_nach_erweiterung, ERWEITERUNG_INFO, KATEGORIE_INFO
 import game_logic
 import secrets
 import os
-import asyncio
 import random
 from datetime import datetime
 
@@ -1049,7 +1048,7 @@ def verarbeite_aktion(spieler, raum, aktion_typ, ziel_id):
         spieler.jaeger_schuss = False
         ziel = Spieler.query.get(ziel_id)
         if ziel:
-            ergebnis = game_logic.toete_spieler(ziel, "jaeger")
+            game_logic.toete_spieler(ziel, "jaeger")
             # SICHER: Nur Name wird geteilt, Rolle erst nach Tod
             emit(
                 "spieler_gestorben",

--- a/audio.py
+++ b/audio.py
@@ -106,11 +106,15 @@ def text_zu_audio_elevenlabs(
         },
     }
 
-    response = requests.post(url, headers=headers, json=payload, timeout=30)
-    response.raise_for_status()
+    try:
+        response = requests.post(url, headers=headers, json=payload, timeout=30)
+        response.raise_for_status()
 
-    audio_datei.write_bytes(response.content)
-    return str(audio_datei)
+        audio_datei.write_bytes(response.content)
+        return str(audio_datei)
+    except (requests.RequestException, IOError) as e:
+        print(f"[ELEVENLABS] API-Fehler: {e}")
+        return None
 
 
 def text_zu_audio_elevenlabs_sync(

--- a/audio.py
+++ b/audio.py
@@ -12,51 +12,51 @@ from pathlib import Path
 import requests
 
 # Ordner für Audio-Cache
-AUDIO_CACHE_DIR = Path('static/audio/cache')
+AUDIO_CACHE_DIR = Path("static/audio/cache")
 AUDIO_CACHE_DIR.mkdir(parents=True, exist_ok=True)
 
-ELEVENLABS_VOICE_ID = os.environ.get('ELEVENLABS_VOICE_ID', 'g1jpii0iyvtRs8fqXsd1')
-ELEVENLABS_MODEL = os.environ.get('ELEVENLABS_MODEL_ID', 'eleven_multilingual_v2')
-ELEVENLABS_API_KEY = os.environ.get('ELEVENLABS_API_KEY')
-ENABLE_ELEVENLABS = os.environ.get('ENABLE_ELEVENLABS', 'false').lower() == 'true'
+ELEVENLABS_VOICE_ID = os.environ.get("ELEVENLABS_VOICE_ID", "g1jpii0iyvtRs8fqXsd1")
+ELEVENLABS_MODEL = os.environ.get("ELEVENLABS_MODEL_ID", "eleven_multilingual_v2")
+ELEVENLABS_API_KEY = os.environ.get("ELEVENLABS_API_KEY")
+ENABLE_ELEVENLABS = os.environ.get("ENABLE_ELEVENLABS", "false").lower() == "true"
 
 # Deutsche Stimmen für edge-tts
 STIMMEN = {
-    'maennlich': 'de-DE-ConradNeural',      # Männliche deutsche Stimme
-    'weiblich': 'de-DE-KatjaNeural',        # Weibliche deutsche Stimme  
-    'dramatisch': 'de-DE-ConradNeural',     # Für dramatische Momente
-    'fluestern': 'de-DE-KatjaNeural',       # Für Flüster-Effekte
+    "maennlich": "de-DE-ConradNeural",  # Männliche deutsche Stimme
+    "weiblich": "de-DE-KatjaNeural",  # Weibliche deutsche Stimme
+    "dramatisch": "de-DE-ConradNeural",  # Für dramatische Momente
+    "fluestern": "de-DE-KatjaNeural",  # Für Flüster-Effekte
 }
 
 # Standard-Stimme für Erzähler
-DEFAULT_VOICE = 'de-DE-ConradNeural'
+DEFAULT_VOICE = "de-DE-ConradNeural"
 
 # Audio-Einstellungen pro Kontext
 AUDIO_EINSTELLUNGEN = {
-    'normal': {
-        'rate': '+0%',
-        'pitch': '+0Hz',
-        'volume': '+0%',
+    "normal": {
+        "rate": "+0%",
+        "pitch": "+0Hz",
+        "volume": "+0%",
     },
-    'dramatisch': {
-        'rate': '-10%',
-        'pitch': '-5Hz',
-        'volume': '+10%',
+    "dramatisch": {
+        "rate": "-10%",
+        "pitch": "-5Hz",
+        "volume": "+10%",
     },
-    'fluestern': {
-        'rate': '-20%',
-        'pitch': '+5Hz',
-        'volume': '-30%',
+    "fluestern": {
+        "rate": "-20%",
+        "pitch": "+5Hz",
+        "volume": "-30%",
     },
-    'aufgeregt': {
-        'rate': '+15%',
-        'pitch': '+10Hz',
-        'volume': '+5%',
+    "aufgeregt": {
+        "rate": "+15%",
+        "pitch": "+10Hz",
+        "volume": "+5%",
     },
-    'langsam': {
-        'rate': '-25%',
-        'pitch': '+0Hz',
-        'volume': '+0%',
+    "langsam": {
+        "rate": "-25%",
+        "pitch": "+0Hz",
+        "volume": "+0%",
     },
 }
 
@@ -75,8 +75,8 @@ def elevenlabs_aktiv() -> bool:
 def text_zu_audio_elevenlabs(
     text: str,
     stimme: str | None = None,
-    stil: str = 'normal',
-    force_regenerate: bool = False
+    stil: str = "normal",
+    force_regenerate: bool = False,
 ) -> str | None:
     """
     ElevenLabs Text-to-Speech mit Caching.
@@ -94,19 +94,16 @@ def text_zu_audio_elevenlabs(
         return str(audio_datei)
 
     url = f"https://api.elevenlabs.io/v1/text-to-speech/{voice_id}"
-    headers = {
-        'xi-api-key': ELEVENLABS_API_KEY,
-        'Accept': 'audio/mpeg'
-    }
+    headers = {"xi-api-key": ELEVENLABS_API_KEY, "Accept": "audio/mpeg"}
     payload = {
-        'text': text,
-        'model_id': ELEVENLABS_MODEL,
-        'voice_settings': {
-            'stability': 0.45,
-            'similarity_boost': 0.9,
-            'style': 0.55 if stil == 'dramatisch' else 0.25,
-            'use_speaker_boost': True
-        }
+        "text": text,
+        "model_id": ELEVENLABS_MODEL,
+        "voice_settings": {
+            "stability": 0.45,
+            "similarity_boost": 0.9,
+            "style": 0.55 if stil == "dramatisch" else 0.25,
+            "use_speaker_boost": True,
+        },
     }
 
     response = requests.post(url, headers=headers, json=payload, timeout=30)
@@ -119,62 +116,64 @@ def text_zu_audio_elevenlabs(
 def text_zu_audio_elevenlabs_sync(
     text: str,
     stimme: str | None = None,
-    stil: str = 'normal',
-    force_regenerate: bool = False
+    stil: str = "normal",
+    force_regenerate: bool = False,
 ) -> str | None:
     """Synchroner Wrapper für die ElevenLabs API."""
-    return text_zu_audio_elevenlabs(text, stimme=stimme, stil=stil, force_regenerate=force_regenerate)
+    return text_zu_audio_elevenlabs(
+        text, stimme=stimme, stil=stil, force_regenerate=force_regenerate
+    )
 
 
 async def text_zu_audio(
     text: str,
     stimme: str = DEFAULT_VOICE,
-    stil: str = 'normal',
-    force_regenerate: bool = False
+    stil: str = "normal",
+    force_regenerate: bool = False,
 ) -> str:
     """
     Wandelt Text in Audio um und gibt den Dateipfad zurück.
-    
+
     Args:
         text: Der zu sprechende Text
         stimme: Die edge-tts Stimme (de-DE-ConradNeural, de-DE-KatjaNeural)
         stil: Der Sprechstil (normal, dramatisch, fluestern, aufgeregt, langsam)
         force_regenerate: Wenn True, wird auch gecachtes Audio neu generiert
-    
+
     Returns:
         Relativer Pfad zur Audio-Datei
     """
     # Generiere Hash für Caching
     audio_hash = generiere_audio_hash(text, stimme, stil)
     audio_datei = AUDIO_CACHE_DIR / f"{audio_hash}.mp3"
-    
+
     # Prüfe ob bereits gecacht
     if audio_datei.exists() and not force_regenerate:
         return str(audio_datei)
-    
+
     # Hole Einstellungen für den Stil
-    einstellungen = AUDIO_EINSTELLUNGEN.get(stil, AUDIO_EINSTELLUNGEN['normal'])
-    
+    einstellungen = AUDIO_EINSTELLUNGEN.get(stil, AUDIO_EINSTELLUNGEN["normal"])
+
     # Erstelle TTS-Kommunikation
     communicate = edge_tts.Communicate(
         text=text,
         voice=stimme,
-        rate=einstellungen['rate'],
-        pitch=einstellungen['pitch'],
-        volume=einstellungen['volume']
+        rate=einstellungen["rate"],
+        pitch=einstellungen["pitch"],
+        volume=einstellungen["volume"],
     )
-    
+
     # Speichere Audio
     await communicate.save(str(audio_datei))
-    
+
     return str(audio_datei)
 
 
 def text_zu_audio_sync(
     text: str,
     stimme: str = DEFAULT_VOICE,
-    stil: str = 'normal',
-    force_regenerate: bool = False
+    stil: str = "normal",
+    force_regenerate: bool = False,
 ) -> str:
     """Synchrone Wrapper-Funktion für text_zu_audio."""
     return asyncio.run(text_zu_audio(text, stimme, stil, force_regenerate))
@@ -183,105 +182,103 @@ def text_zu_audio_sync(
 async def generiere_phasen_audio():
     """Generiert alle Standard-Phasen-Audio-Dateien vorab."""
     from models import PHASEN_TEXTE
-    
+
     print("Generiere Phasen-Audio...")
-    
+
     for phase_id, phase_info in PHASEN_TEXTE.items():
-        text = phase_info.get('text', '')
+        text = phase_info.get("text", "")
         if text:
             # Bestimme Stil basierend auf Phase
-            stil = 'normal'
-            if 'werwolf' in phase_id.lower():
-                stil = 'dramatisch'
-            elif 'tot' in text.lower() or 'stirbt' in text.lower():
-                stil = 'dramatisch'
-            elif 'schläft' in text.lower():
-                stil = 'langsam'
-            
+            stil = "normal"
+            if "werwolf" in phase_id.lower():
+                stil = "dramatisch"
+            elif "tot" in text.lower() or "stirbt" in text.lower():
+                stil = "dramatisch"
+            elif "schläft" in text.lower():
+                stil = "langsam"
+
             datei = await text_zu_audio(text, stil=stil)
             print(f"  {phase_id}: {datei}")
-    
+
     print("Fertig!")
 
 
 async def generiere_rollen_audio():
     """Generiert Erzähler-Audio für alle Rollen."""
     from models import ROLLEN
-    
+
     print("Generiere Rollen-Audio...")
-    
+
     for rolle_name, rolle_info in ROLLEN.items():
         # Nacht-Text
-        nacht_text = rolle_info.get('erzaehler_nacht')
+        nacht_text = rolle_info.get("erzaehler_nacht")
         if nacht_text:
-            datei = await text_zu_audio(nacht_text, stil='langsam')
+            datei = await text_zu_audio(nacht_text, stil="langsam")
             print(f"  {rolle_name} (Nacht): {datei}")
-        
+
         # Tag-Text
-        tag_text = rolle_info.get('erzaehler_tag')
-        if tag_text and '{' not in tag_text:  # Nur statische Texte
-            datei = await text_zu_audio(tag_text, stil='normal')
+        tag_text = rolle_info.get("erzaehler_tag")
+        if tag_text and "{" not in tag_text:  # Nur statische Texte
+            datei = await text_zu_audio(tag_text, stil="normal")
             print(f"  {rolle_name} (Tag): {datei}")
-    
+
     print("Fertig!")
 
 
 async def dynamischer_text_zu_audio(
-    template: str,
-    variablen: dict,
-    stil: str = 'normal'
+    template: str, variablen: dict, stil: str = "normal"
 ) -> str:
     """
     Generiert Audio für dynamische Texte mit Variablen.
-    
+
     Args:
         template: Text-Template mit {variablen}
         variablen: Dictionary mit Variablen-Werten
         stil: Sprechstil
-    
+
     Returns:
         Pfad zur Audio-Datei
     """
     # Ersetze Variablen im Template
     text = template.format(**variablen)
-    
+
     # Generiere Audio (wird gecacht wenn gleicher Text)
     return await text_zu_audio(text, stil=stil)
 
 
 # Hinweis-Audio-Effekte
 HINWEIS_AUDIO = {
-    'heulen_fern': {
-        'beschreibung': 'Fernes Wolfsheulen',
-        'datei': 'distant_howl.mp3',
+    "heulen_fern": {
+        "beschreibung": "Fernes Wolfsheulen",
+        "datei": "distant_howl.mp3",
     },
-    'kratzen': {
-        'beschreibung': 'Kratzendes Geräusch',
-        'datei': 'scratch.mp3',
+    "kratzen": {
+        "beschreibung": "Kratzendes Geräusch",
+        "datei": "scratch.mp3",
     },
-    'herzschlag': {
-        'beschreibung': 'Schneller Herzschlag',
-        'datei': 'heartbeat_fast.mp3',
+    "herzschlag": {
+        "beschreibung": "Schneller Herzschlag",
+        "datei": "heartbeat_fast.mp3",
     },
-    'fluestern': {
-        'beschreibung': 'Unverständliches Flüstern',
-        'datei': 'whisper.mp3',
+    "fluestern": {
+        "beschreibung": "Unverständliches Flüstern",
+        "datei": "whisper.mp3",
     },
-    'stolpern': {
-        'beschreibung': 'Stolper-Geräusch',
-        'datei': 'stumble.mp3',
+    "stolpern": {
+        "beschreibung": "Stolper-Geräusch",
+        "datei": "stumble.mp3",
     },
-    'kichern': {
-        'beschreibung': 'Böses Kichern',
-        'datei': 'evil_chuckle.mp3',
+    "kichern": {
+        "beschreibung": "Böses Kichern",
+        "datei": "evil_chuckle.mp3",
     },
-    'schatten': {
-        'beschreibung': 'Schatten-Swoosh',
-        'datei': 'shadow_swoosh.mp3',
+    "schatten": {
+        "beschreibung": "Schatten-Swoosh",
+        "datei": "shadow_swoosh.mp3",
     },
-    'verdaechtig': {
-        'beschreibung': 'Verdächtiges Geräusch',
-        'datei': 'suspicious.mp3',
+    "verdaechtig": {
+        "beschreibung": "Verdächtiges Geräusch",
+        "datei": "suspicious.mp3",
     },
 }
 
@@ -292,53 +289,50 @@ async def generiere_hinweis_audio_mit_tts():
     Für einfache Geräusche verwenden wir kurze gesprochene Texte.
     """
     texte = {
-        'distant_howl': 'Auuuuuu...',
-        'scratch': '*kratz kratz*',
-        'heartbeat_fast': 'Bum bum bum bum',
-        'whisper': '*psst psst*',
-        'stumble': '*stolper*',
-        'evil_chuckle': 'He he he...',
-        'shadow_swoosh': '*wusch*',
-        'suspicious': 'Hmm...',
+        "distant_howl": "Auuuuuu...",
+        "scratch": "*kratz kratz*",
+        "heartbeat_fast": "Bum bum bum bum",
+        "whisper": "*psst psst*",
+        "stumble": "*stolper*",
+        "evil_chuckle": "He he he...",
+        "shadow_swoosh": "*wusch*",
+        "suspicious": "Hmm...",
     }
-    
-    audio_dir = Path('static/audio/hints')
+
+    audio_dir = Path("static/audio/hints")
     audio_dir.mkdir(parents=True, exist_ok=True)
-    
+
     for name, text in texte.items():
         datei = audio_dir / f"{name}.mp3"
         if not datei.exists():
             communicate = edge_tts.Communicate(
-                text=text,
-                voice='de-DE-KatjaNeural',
-                rate='-20%',
-                volume='-10%'
+                text=text, voice="de-DE-KatjaNeural", rate="-20%", volume="-10%"
             )
             await communicate.save(str(datei))
             print(f"  Hinweis-Audio erstellt: {name}")
 
 
 # CLI für Audio-Generierung
-if __name__ == '__main__':
+if __name__ == "__main__":
     import sys
-    
+
     if len(sys.argv) > 1:
         befehl = sys.argv[1]
-        
-        if befehl == 'phasen':
+
+        if befehl == "phasen":
             asyncio.run(generiere_phasen_audio())
-        elif befehl == 'rollen':
+        elif befehl == "rollen":
             asyncio.run(generiere_rollen_audio())
-        elif befehl == 'hinweise':
+        elif befehl == "hinweise":
             asyncio.run(generiere_hinweis_audio_mit_tts())
-        elif befehl == 'alle':
+        elif befehl == "alle":
             asyncio.run(generiere_phasen_audio())
             asyncio.run(generiere_rollen_audio())
             asyncio.run(generiere_hinweis_audio_mit_tts())
-        elif befehl == 'test':
+        elif befehl == "test":
             # Test mit einem Text
             test_text = "Das Dorf schläft ein. Alle Spieler schließen die Augen."
-            datei = text_zu_audio_sync(test_text, stil='langsam')
+            datei = text_zu_audio_sync(test_text, stil="langsam")
             print(f"Test-Audio erstellt: {datei}")
         else:
             print(f"Unbekannter Befehl: {befehl}")
@@ -346,5 +340,3 @@ if __name__ == '__main__':
     else:
         print("Webwölfe Audio-Generator")
         print("Usage: python audio.py [phasen|rollen|hinweise|alle|test]")
-
-

--- a/audio.py
+++ b/audio.py
@@ -9,10 +9,16 @@ import edge_tts
 import os
 import hashlib
 from pathlib import Path
+import requests
 
 # Ordner für Audio-Cache
 AUDIO_CACHE_DIR = Path('static/audio/cache')
 AUDIO_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+ELEVENLABS_VOICE_ID = os.environ.get('ELEVENLABS_VOICE_ID', 'g1jpii0iyvtRs8fqXsd1')
+ELEVENLABS_MODEL = os.environ.get('ELEVENLABS_MODEL_ID', 'eleven_multilingual_v2')
+ELEVENLABS_API_KEY = os.environ.get('ELEVENLABS_API_KEY')
+ENABLE_ELEVENLABS = os.environ.get('ENABLE_ELEVENLABS', 'false').lower() == 'true'
 
 # Deutsche Stimmen für edge-tts
 STIMMEN = {
@@ -59,6 +65,65 @@ def generiere_audio_hash(text: str, stimme: str, stil: str) -> str:
     """Generiert einen eindeutigen Hash für Audio-Caching."""
     content = f"{text}_{stimme}_{stil}"
     return hashlib.md5(content.encode()).hexdigest()
+
+
+def elevenlabs_aktiv() -> bool:
+    """Prüft, ob ElevenLabs aktiviert und konfiguriert ist."""
+    return ENABLE_ELEVENLABS and bool(ELEVENLABS_API_KEY)
+
+
+def text_zu_audio_elevenlabs(
+    text: str,
+    stimme: str | None = None,
+    stil: str = 'normal',
+    force_regenerate: bool = False
+) -> str | None:
+    """
+    ElevenLabs Text-to-Speech mit Caching.
+
+    Returns None, falls ElevenLabs nicht aktiviert oder nicht konfiguriert ist.
+    """
+    if not elevenlabs_aktiv():
+        return None
+
+    voice_id = stimme or ELEVENLABS_VOICE_ID
+    audio_hash = generiere_audio_hash(text, f"11_{voice_id}", stil)
+    audio_datei = AUDIO_CACHE_DIR / f"11_{audio_hash}.mp3"
+
+    if audio_datei.exists() and not force_regenerate:
+        return str(audio_datei)
+
+    url = f"https://api.elevenlabs.io/v1/text-to-speech/{voice_id}"
+    headers = {
+        'xi-api-key': ELEVENLABS_API_KEY,
+        'Accept': 'audio/mpeg'
+    }
+    payload = {
+        'text': text,
+        'model_id': ELEVENLABS_MODEL,
+        'voice_settings': {
+            'stability': 0.45,
+            'similarity_boost': 0.9,
+            'style': 0.55 if stil == 'dramatisch' else 0.25,
+            'use_speaker_boost': True
+        }
+    }
+
+    response = requests.post(url, headers=headers, json=payload, timeout=30)
+    response.raise_for_status()
+
+    audio_datei.write_bytes(response.content)
+    return str(audio_datei)
+
+
+def text_zu_audio_elevenlabs_sync(
+    text: str,
+    stimme: str | None = None,
+    stil: str = 'normal',
+    force_regenerate: bool = False
+) -> str | None:
+    """Synchroner Wrapper für die ElevenLabs API."""
+    return text_zu_audio_elevenlabs(text, stimme=stimme, stil=stil, force_regenerate=force_regenerate)
 
 
 async def text_zu_audio(

--- a/game_logic.py
+++ b/game_logic.py
@@ -1,6 +1,7 @@
 """
 Spiellogik fuer das Werwolf-Spiel
 """
+
 import random
 from models import db, Raum, Spieler, SpielAktion, SpielLog, ROLLEN, PHASEN
 
@@ -8,32 +9,32 @@ from models import db, Raum, Spieler, SpielAktion, SpielLog, ROLLEN, PHASEN
 def berechne_rollen(spieler_anzahl: int, mit_erzaehler: bool = False) -> dict:
     """
     Berechnet die Rollenverteilung basierend auf der Spieleranzahl.
-    
+
     Balanced for games from 5 to 1000+ players.
-    
+
     Balance ratios (based on research):
     - Werewolves: ~20-22% of players (1 wolf per 4-5 villagers)
     - Special village roles: Scale with player count
     - Wolves:Villagers:Specials ratio around 1:2:1 to 1:3:1
     - Solo/neutral roles added sparingly in larger games
-    
+
     Args:
         spieler_anzahl: Anzahl der Spieler
         mit_erzaehler: Ob ein Erzaehler dabei ist
-        
+
     Returns:
         Dictionary mit Rollen und deren Anzahl
     """
     effektive_anzahl = spieler_anzahl - (1 if mit_erzaehler else 0)
-    
+
     if effektive_anzahl < 5:
         effektive_anzahl = 5  # Minimum players
-    
+
     rollen = {}
-    
+
     if mit_erzaehler:
-        rollen['Erzaehler'] = 1
-    
+        rollen["Erzaehler"] = 1
+
     # ========================================================================
     # WEREWOLF TEAM CALCULATION (Target: ~20-22% of players)
     # ========================================================================
@@ -49,197 +50,198 @@ def berechne_rollen(spieler_anzahl: int, mit_erzaehler: bool = False) -> dict:
     else:
         # For massive games (500+): ~15-18% wolves (voting power is strong)
         werwolf_basis = max(20, int(effektive_anzahl * 0.16))
-    
+
     # Add werewolf variants for large games
-    rollen['Werwolf'] = werwolf_basis
-    
+    rollen["Werwolf"] = werwolf_basis
+
     # Special werewolf roles (scale with game size)
     if effektive_anzahl >= 13:
-        rollen['Weißer Wolf'] = max(1, effektive_anzahl // 100)  # Solo wolf
+        rollen["Weißer Wolf"] = max(1, effektive_anzahl // 100)  # Solo wolf
     if effektive_anzahl >= 17:
-        rollen['Urwolf'] = max(1, effektive_anzahl // 150)
+        rollen["Urwolf"] = max(1, effektive_anzahl // 150)
     if effektive_anzahl >= 25:
-        rollen['Wolfsjunge'] = max(1, effektive_anzahl // 200)
+        rollen["Wolfsjunge"] = max(1, effektive_anzahl // 200)
     if effektive_anzahl >= 100:
-        rollen['Wolf im Schafspelz'] = max(1, effektive_anzahl // 150)
+        rollen["Wolf im Schafspelz"] = max(1, effektive_anzahl // 150)
     if effektive_anzahl >= 200:
-        rollen['Werwolfseherin'] = max(1, effektive_anzahl // 250)
+        rollen["Werwolfseherin"] = max(1, effektive_anzahl // 250)
     if effektive_anzahl >= 300:
-        rollen['Einsamer Wolf'] = max(1, effektive_anzahl // 400)
-    
+        rollen["Einsamer Wolf"] = max(1, effektive_anzahl // 400)
+
     # ========================================================================
     # VILLAGE SPECIAL ROLES (Scale to provide balance)
     # ========================================================================
     # Information roles (critical for village success in large games)
     if effektive_anzahl >= 5:
-        rollen['Seherin'] = max(1, effektive_anzahl // 50)  # 1 per 50 players
+        rollen["Seherin"] = max(1, effektive_anzahl // 50)  # 1 per 50 players
     if effektive_anzahl >= 6:
-        rollen['Hexe'] = max(1, effektive_anzahl // 75)  # Heals + kills
+        rollen["Hexe"] = max(1, effektive_anzahl // 75)  # Heals + kills
     if effektive_anzahl >= 8:
-        rollen['Amor'] = max(1, effektive_anzahl // 150)
+        rollen["Amor"] = max(1, effektive_anzahl // 150)
     if effektive_anzahl >= 10:
-        rollen['Jäger'] = max(1, effektive_anzahl // 60)  # Death trigger
+        rollen["Jäger"] = max(1, effektive_anzahl // 60)  # Death trigger
     if effektive_anzahl >= 12:
-        rollen['Heiler'] = max(1, effektive_anzahl // 80)  # Protection
-    
+        rollen["Heiler"] = max(1, effektive_anzahl // 80)  # Protection
+
     # More advanced roles for larger games
     if effektive_anzahl >= 15:
-        rollen['Alter Mann'] = max(1, effektive_anzahl // 100)
+        rollen["Alter Mann"] = max(1, effektive_anzahl // 100)
     if effektive_anzahl >= 18:
-        rollen['Medium'] = max(1, effektive_anzahl // 100)
+        rollen["Medium"] = max(1, effektive_anzahl // 100)
     if effektive_anzahl >= 20:
-        rollen['Rabe'] = max(1, effektive_anzahl // 120)
+        rollen["Rabe"] = max(1, effektive_anzahl // 120)
     if effektive_anzahl >= 25:
-        rollen['Prinz'] = max(1, effektive_anzahl // 150)
+        rollen["Prinz"] = max(1, effektive_anzahl // 150)
     if effektive_anzahl >= 30:
-        rollen['Bürgermeister'] = max(1, effektive_anzahl // 200)
+        rollen["Bürgermeister"] = max(1, effektive_anzahl // 200)
     if effektive_anzahl >= 35:
-        rollen['Leibwächter'] = max(1, effektive_anzahl // 150)
+        rollen["Leibwächter"] = max(1, effektive_anzahl // 150)
     if effektive_anzahl >= 40:
-        rollen['Aurenseherin'] = max(1, effektive_anzahl // 200)
+        rollen["Aurenseherin"] = max(1, effektive_anzahl // 200)
     if effektive_anzahl >= 50:
-        rollen['Seherlehrling'] = max(1, effektive_anzahl // 150)
+        rollen["Seherlehrling"] = max(1, effektive_anzahl // 150)
     if effektive_anzahl >= 60:
-        rollen['Tratschweib'] = max(1, effektive_anzahl // 200)
+        rollen["Tratschweib"] = max(1, effektive_anzahl // 200)
     if effektive_anzahl >= 75:
-        rollen['Bärenbändiger'] = max(1, effektive_anzahl // 250)
-    
+        rollen["Bärenbändiger"] = max(1, effektive_anzahl // 250)
+
     # Group knowledge roles for very large games
     if effektive_anzahl >= 80:
         schwestern_paare = max(1, effektive_anzahl // 200)
-        rollen['Zwei Schwestern'] = schwestern_paare * 2
+        rollen["Zwei Schwestern"] = schwestern_paare * 2
     if effektive_anzahl >= 100:
         brueder_gruppen = max(1, effektive_anzahl // 250)
-        rollen['Drei Brüder'] = brueder_gruppen * 3
+        rollen["Drei Brüder"] = brueder_gruppen * 3
     if effektive_anzahl >= 120:
         freimaurer_anzahl = max(2, effektive_anzahl // 150)
-        rollen['Freimaurer'] = freimaurer_anzahl
-    
+        rollen["Freimaurer"] = freimaurer_anzahl
+
     # Defensive/utility roles for massive games
     if effektive_anzahl >= 150:
-        rollen['Kräuterweib'] = max(1, effektive_anzahl // 300)
-        rollen['Zauberer'] = max(1, effektive_anzahl // 350)
+        rollen["Kräuterweib"] = max(1, effektive_anzahl // 300)
+        rollen["Zauberer"] = max(1, effektive_anzahl // 350)
     if effektive_anzahl >= 200:
-        rollen['Hure'] = max(1, effektive_anzahl // 300)
-        rollen['Doppelgänger'] = max(1, effektive_anzahl // 400)
+        rollen["Hure"] = max(1, effektive_anzahl // 300)
+        rollen["Doppelgänger"] = max(1, effektive_anzahl // 400)
     if effektive_anzahl >= 300:
-        rollen['Sandmann'] = max(1, effektive_anzahl // 400)
-        rollen['Buddler'] = max(1, effektive_anzahl // 500)
+        rollen["Sandmann"] = max(1, effektive_anzahl // 400)
+        rollen["Buddler"] = max(1, effektive_anzahl // 500)
     if effektive_anzahl >= 400:
-        rollen['Ergebene Magd'] = max(1, effektive_anzahl // 500)
-        rollen['Demoskopin'] = max(1, effektive_anzahl // 500)
+        rollen["Ergebene Magd"] = max(1, effektive_anzahl // 500)
+        rollen["Demoskopin"] = max(1, effektive_anzahl // 500)
     if effektive_anzahl >= 500:
-        rollen['Putzfrau'] = max(1, effektive_anzahl // 600)
-        rollen['Gaukler'] = max(1, effektive_anzahl // 600)
-    
+        rollen["Putzfrau"] = max(1, effektive_anzahl // 600)
+        rollen["Gaukler"] = max(1, effektive_anzahl // 600)
+
     # Aggressive village roles for balance in huge games
     if effektive_anzahl >= 100:
-        rollen['Kamikaze'] = max(1, effektive_anzahl // 300)
+        rollen["Kamikaze"] = max(1, effektive_anzahl // 300)
     if effektive_anzahl >= 200:
-        rollen['Flammenmann'] = max(1, effektive_anzahl // 500)
+        rollen["Flammenmann"] = max(1, effektive_anzahl // 500)
     if effektive_anzahl >= 400:
-        rollen['Inquisitor'] = max(1, effektive_anzahl // 600)
-    
+        rollen["Inquisitor"] = max(1, effektive_anzahl // 600)
+
     # ========================================================================
     # SOLO/NEUTRAL ROLES (Sparsely added - max ~3-5% of players)
     # ========================================================================
     if effektive_anzahl >= 15:
-        rollen['Dorfdepp'] = max(1, effektive_anzahl // 200)
+        rollen["Dorfdepp"] = max(1, effektive_anzahl // 200)
     if effektive_anzahl >= 50:
-        rollen['Flötenspieler'] = max(1, effektive_anzahl // 250)
+        rollen["Flötenspieler"] = max(1, effektive_anzahl // 250)
     if effektive_anzahl >= 100:
-        rollen['Selbstmörder'] = max(1, effektive_anzahl // 300)
+        rollen["Selbstmörder"] = max(1, effektive_anzahl // 300)
     if effektive_anzahl >= 150:
-        rollen['Henker'] = max(1, effektive_anzahl // 400)
+        rollen["Henker"] = max(1, effektive_anzahl // 400)
     if effektive_anzahl >= 300:
-        rollen['Gerber'] = max(1, effektive_anzahl // 500)
+        rollen["Gerber"] = max(1, effektive_anzahl // 500)
     if effektive_anzahl >= 400:
-        rollen['Pyromane'] = max(1, effektive_anzahl // 600)
+        rollen["Pyromane"] = max(1, effektive_anzahl // 600)
     if effektive_anzahl >= 500:
-        rollen['Engel'] = max(1, effektive_anzahl // 700)
-    
+        rollen["Engel"] = max(1, effektive_anzahl // 700)
+
     # ========================================================================
     # OTHER TEAMS (Vampires, Zombies - added in very large games)
     # ========================================================================
     if effektive_anzahl >= 200:
-        rollen['Vampir'] = max(1, effektive_anzahl // 300)
+        rollen["Vampir"] = max(1, effektive_anzahl // 300)
     if effektive_anzahl >= 400:
-        rollen['Zombie'] = max(1, effektive_anzahl // 500)
-    
+        rollen["Zombie"] = max(1, effektive_anzahl // 500)
+
     # ========================================================================
     # EVIL SUPPORT ROLES (to help werewolf team in large games)
     # ========================================================================
     if effektive_anzahl >= 75:
-        rollen['Giftmischerin'] = max(1, effektive_anzahl // 250)
+        rollen["Giftmischerin"] = max(1, effektive_anzahl // 250)
     if effektive_anzahl >= 150:
-        rollen['Hexenmeister'] = max(1, effektive_anzahl // 400)
+        rollen["Hexenmeister"] = max(1, effektive_anzahl // 400)
     if effektive_anzahl >= 300:
-        rollen['Dunkler Priester'] = max(1, effektive_anzahl // 500)
-    
+        rollen["Dunkler Priester"] = max(1, effektive_anzahl // 500)
+
     # ========================================================================
     # DORFBEWOHNER (Fill remaining slots)
     # ========================================================================
-    total_special_roles = sum(v for k, v in rollen.items() if k != 'Erzaehler')
+    total_special_roles = sum(v for k, v in rollen.items() if k != "Erzaehler")
     dorfbewohner_anzahl = effektive_anzahl - total_special_roles
-    
+
     if dorfbewohner_anzahl > 0:
-        rollen['Dorfbewohner'] = dorfbewohner_anzahl
+        rollen["Dorfbewohner"] = dorfbewohner_anzahl
     elif dorfbewohner_anzahl < 0:
         # Too many special roles - reduce werewolves to compensate
         ueberschuss = abs(dorfbewohner_anzahl)
-        print(f"Adjusting roles: reducing Werwolf from {rollen.get('Werwolf', 0)} by {ueberschuss} to fit player count.")
-        if rollen.get('Werwolf', 0) > ueberschuss:
-            rollen['Werwolf'] -= ueberschuss
+        print(
+            f"Adjusting roles: reducing Werwolf from {rollen.get('Werwolf', 0)} by {ueberschuss} to fit player count."
+        )
+        if rollen.get("Werwolf", 0) > ueberschuss:
+            rollen["Werwolf"] -= ueberschuss
         else:
             # Recalculate - this shouldn't happen with proper ratios
             print("Recalculating roles due to excess special roles...")
-            rollen['Dorfbewohner'] = 1
-    
+            rollen["Dorfbewohner"] = 1
+
     return rollen
 
 
 def verteile_rollen(raum: Raum) -> dict:
     """
     Verteilt die Rollen an alle Spieler im Raum.
-    
+
     Args:
         raum: Der Spielraum
-        
+
     Returns:
         Dictionary mit Spieler-ID zu Rolle Mapping
     """
     spieler = Spieler.query.filter_by(raum_id=raum.id, ist_erzaehler=False).all()
     spieler_anzahl = len(spieler)
-    
+
     erzaehler = Spieler.query.filter_by(raum_id=raum.id, ist_erzaehler=True).first()
-    
+
     rollen_verteilung = berechne_rollen(
-        spieler_anzahl + (1 if erzaehler else 0),
-        mit_erzaehler=bool(erzaehler)
+        spieler_anzahl + (1 if erzaehler else 0), mit_erzaehler=bool(erzaehler)
     )
-    
+
     # Erstelle Liste aller zu verteilenden Rollen
     rollen_liste = []
     for rolle, anzahl in rollen_verteilung.items():
-        if rolle != 'Erzaehler':
+        if rolle != "Erzaehler":
             rollen_liste.extend([rolle] * anzahl)
-    
+
     # Mische die Rollen
     random.shuffle(rollen_liste)
     random.shuffle(spieler)
-    
+
     # Weise Rollen zu
     ergebnis = {}
     for i, spieler_obj in enumerate(spieler):
         if i < len(rollen_liste):
             spieler_obj.rolle = rollen_liste[i]
             ergebnis[spieler_obj.id] = rollen_liste[i]
-    
+
     # Erzaehler bekommt spezielle Rolle
     if erzaehler:
-        erzaehler.rolle = 'Erzaehler'
-        ergebnis[erzaehler.id] = 'Erzaehler'
-    
+        erzaehler.rolle = "Erzaehler"
+        ergebnis[erzaehler.id] = "Erzaehler"
+
     db.session.commit()
     return ergebnis
 
@@ -247,36 +249,36 @@ def verteile_rollen(raum: Raum) -> dict:
 def starte_spiel(raum: Raum) -> bool:
     """
     Startet das Spiel im Raum.
-    
+
     Args:
         raum: Der Spielraum
-        
+
     Returns:
         True wenn erfolgreich gestartet
     """
     spieler = Spieler.query.filter_by(raum_id=raum.id).all()
-    
+
     if len(spieler) < 5:
         return False
-    
+
     verteile_rollen(raum)
-    
+
     raum.spiel_gestartet = True
-    raum.aktuelle_phase = 'rollen_verteilt'
+    raum.aktuelle_phase = "rollen_verteilt"
     raum.runde = 1
-    
+
     # Reset Spieler Status
     for s in spieler:
         s.ist_am_leben = True
-        s.status = 'aktiv'
+        s.status = "aktiv"
         s.hexe_heiltrank = True
         s.hexe_gifttrank = True
         s.jaeger_schuss = True
         s.armor_verliebt = True
         s.verliebt_mit_id = None
-    
+
     log_eintrag(raum.id, "Das Spiel hat begonnen! Die Rollen wurden verteilt.")
-    
+
     db.session.commit()
     return True
 
@@ -284,34 +286,37 @@ def starte_spiel(raum: Raum) -> bool:
 def hat_spieler_mit_rolle(raum: Raum, rolle: str) -> bool:
     """
     Prueft ob es einen lebenden Spieler mit der gegebenen Rolle gibt.
-    
+
     Args:
         raum: Der Spielraum
         rolle: Die zu prüfende Rolle
-        
+
     Returns:
         True wenn Rolle existiert, False sonst
     """
-    return Spieler.query.filter_by(raum_id=raum.id, rolle=rolle, ist_am_leben=True).first() is not None
+    return (
+        Spieler.query.filter_by(raum_id=raum.id, rolle=rolle, ist_am_leben=True).first()
+        is not None
+    )
 
 
 def _normalisiere_phase_name(phase_name: str) -> str:
     """Bringt dynamische Phasennamen in das PHASEN-Schema."""
 
     replacements = {
-        'ä': 'ae',
-        'ö': 'oe',
-        'ü': 'ue',
-        'ß': 'ss',
+        "ä": "ae",
+        "ö": "oe",
+        "ü": "ue",
+        "ß": "ss",
     }
 
     normalisiert = phase_name.strip().lower()
     for alt, neu in replacements.items():
         normalisiert = normalisiert.replace(alt, neu)
 
-    normalisiert = normalisiert.replace(' ', '_')
-    while '__' in normalisiert:
-        normalisiert = normalisiert.replace('__', '_')
+    normalisiert = normalisiert.replace(" ", "_")
+    while "__" in normalisiert:
+        normalisiert = normalisiert.replace("__", "_")
     return normalisiert
 
 
@@ -352,48 +357,48 @@ def phasennamen_zu_rollen_mapping() -> dict:
 def naechste_phase(raum: Raum) -> str:
     """
     Wechselt zur naechsten Spielphase.
-    
+
     Args:
         raum: Der Spielraum
-        
+
     Returns:
         Name der neuen Phase
     """
     aktuelle_idx = PHASEN.index(raum.aktuelle_phase)
     phase_mapping = phasennamen_zu_rollen_mapping()
-    
+
     # Spezielle Phasen-Logik
-    if raum.aktuelle_phase == 'armor_phase':
+    if raum.aktuelle_phase == "armor_phase":
         # Armor nur in Runde 1
         if raum.runde > 1:
-            naechste_idx = PHASEN.index('seherin_phase')
+            naechste_idx = PHASEN.index("seherin_phase")
         else:
             naechste_idx = aktuelle_idx + 1
-    elif raum.aktuelle_phase == 'verliebte_info':
+    elif raum.aktuelle_phase == "verliebte_info":
         if raum.runde > 1:
-            naechste_idx = PHASEN.index('seherin_phase')
+            naechste_idx = PHASEN.index("seherin_phase")
         else:
             naechste_idx = aktuelle_idx + 1
-    elif raum.aktuelle_phase == 'tag_ende':
+    elif raum.aktuelle_phase == "tag_ende":
         raum.runde += 1
-        naechste_idx = PHASEN.index('nacht_start')
-    elif raum.aktuelle_phase == 'spiel_ende':
+        naechste_idx = PHASEN.index("nacht_start")
+    elif raum.aktuelle_phase == "spiel_ende":
         naechste_idx = aktuelle_idx  # Bleibt bei spiel_ende
     else:
         naechste_idx = aktuelle_idx + 1
-    
+
     # Pruefe ob die naechste Phase eine erforderliche Rolle hat
     max_iterations = len(PHASEN)
     iterations = 0
     while iterations < max_iterations:
         if naechste_idx >= len(PHASEN):
-            naechste_idx = PHASEN.index('nacht_start')
+            naechste_idx = PHASEN.index("nacht_start")
             raum.runde += 1
             iterations += 1
             continue
-        
+
         naechste_phase_name = PHASEN[naechste_idx]
-        
+
         # Prüfe ob diese Phase eine erforderliche Rolle benötigt
         if naechste_phase_name in phase_mapping:
             erforderliche_rolle = phase_mapping[naechste_phase_name]
@@ -402,17 +407,17 @@ def naechste_phase(raum: Raum) -> str:
                 naechste_idx += 1
                 iterations += 1
                 continue
-        
+
         # Phase ist gültig
         break
-    
+
     if naechste_idx >= len(PHASEN):
-        naechste_idx = PHASEN.index('nacht_start')
+        naechste_idx = PHASEN.index("nacht_start")
         raum.runde += 1
-        
+
     raum.aktuelle_phase = PHASEN[naechste_idx]
     db.session.commit()
-    
+
     return raum.aktuelle_phase
 
 
@@ -423,40 +428,41 @@ def ist_werwolf_rolle(rolle: str) -> bool:
     """
     from roles import RoleRegistry
     from roles.enums import Team
-    
+
     rolle_obj = RoleRegistry.get(rolle)
     if rolle_obj:
         return rolle_obj.info.team == Team.WERWOLF
-    
+
     rolle_info = ROLLEN.get(rolle, {})
     if rolle_info:
-        return rolle_info.get('team') == 'werwolf'
-    
-    return 'werwolf' in (rolle or '').lower()
+        return rolle_info.get("team") == "werwolf"
+
+    return "werwolf" in (rolle or "").lower()
 
 
 def pruefe_spielende(raum: Raum) -> dict | None:
     """
     Prueft ob das Spiel zu Ende ist.
-    
+
     Args:
         raum: Der Spielraum
-        
+
     Returns:
         Dictionary mit Gewinner-Info oder None wenn Spiel weitergeht
     """
-    lebende = Spieler.query.filter_by(raum_id=raum.id, ist_am_leben=True, ist_erzaehler=False).all()
-    
+    lebende = Spieler.query.filter_by(
+        raum_id=raum.id, ist_am_leben=True, ist_erzaehler=False
+    ).all()
+
     # Beruecksichtige alle Werwolf-Varianten
     werwoelfe = [s for s in lebende if ist_werwolf_rolle(s.rolle)]
     dorfbewohner = [s for s in lebende if not ist_werwolf_rolle(s.rolle)]
-    
+
     # Verliebten-Check
     verliebte = Spieler.query.filter(
-        Spieler.raum_id == raum.id,
-        Spieler.verliebt_mit_id.isnot(None)
+        Spieler.raum_id == raum.id, Spieler.verliebt_mit_id.isnot(None)
     ).all()
-    
+
     if len(verliebte) == 2 and all(v.ist_am_leben for v in verliebte):
         # Pruefen ob nur noch die Verliebten leben
         if len(lebende) == 2:
@@ -465,68 +471,67 @@ def pruefe_spielende(raum: Raum) -> dict | None:
             hat_wolf = any(ist_werwolf_rolle(r) for r in rollen)
             if hat_wolf and len(rollen) > 1:
                 return {
-                    'gewinner': 'verliebte',
-                    'nachricht': 'Die Verliebten haben gewonnen! Ihre Liebe hat alle ueberwunden.',
-                    'spieler': [v.name for v in verliebte]
+                    "gewinner": "verliebte",
+                    "nachricht": "Die Verliebten haben gewonnen! Ihre Liebe hat alle ueberwunden.",
+                    "spieler": [v.name for v in verliebte],
                 }
-    
+
     # Keine Werwoelfe mehr
     if len(werwoelfe) == 0:
         return {
-            'gewinner': 'dorf',
-            'nachricht': 'Das Dorf hat gewonnen! Alle Werwoelfe wurden eliminiert.',
-            'spieler': [s.name for s in dorfbewohner]
+            "gewinner": "dorf",
+            "nachricht": "Das Dorf hat gewonnen! Alle Werwoelfe wurden eliminiert.",
+            "spieler": [s.name for s in dorfbewohner],
         }
-    
+
     # Werwoelfe in Ueberzahl oder Gleichstand
     if len(werwoelfe) >= len(dorfbewohner):
         return {
-            'gewinner': 'werwolf',
-            'nachricht': 'Die Werwoelfe haben gewonnen! Das Dorf ist gefallen.',
-            'spieler': [s.name for s in werwoelfe]
+            "gewinner": "werwolf",
+            "nachricht": "Die Werwoelfe haben gewonnen! Das Dorf ist gefallen.",
+            "spieler": [s.name for s in werwoelfe],
         }
-    
+
     return None
 
 
-def toete_spieler(spieler: Spieler, todesart: str = 'unbekannt') -> dict:
+def toete_spieler(spieler: Spieler, todesart: str = "unbekannt") -> dict:
     """
     Toetet einen Spieler.
-    
+
     Args:
         spieler: Der zu toetende Spieler
         todesart: Art des Todes (werwolf, abstimmung, hexe, jaeger)
-        
+
     Returns:
         Dictionary mit Todes-Informationen
     """
     spieler.ist_am_leben = False
-    spieler.status = 'tot'
-    
+    spieler.status = "tot"
+
     ergebnis = {
-        'spieler_id': spieler.id,
-        'spieler_name': spieler.name,
-        'rolle': spieler.rolle,
-        'todesart': todesart,
-        'folge_aktionen': []
+        "spieler_id": spieler.id,
+        "spieler_name": spieler.name,
+        "rolle": spieler.rolle,
+        "todesart": todesart,
+        "folge_aktionen": [],
     }
-    
+
     # Jaeger stirbt - kann noch schiessen
-    if spieler.rolle == 'Jäger' and spieler.jaeger_schuss:
-        ergebnis['folge_aktionen'].append('jaeger_schuss')
-    
+    if spieler.rolle == "Jäger" and spieler.jaeger_schuss:
+        ergebnis["folge_aktionen"].append("jaeger_schuss")
+
     # Verliebter stirbt - Partner stirbt auch
     if spieler.verliebt_mit_id:
         partner = Spieler.query.get(spieler.verliebt_mit_id)
         if partner and partner.ist_am_leben:
-            ergebnis['folge_aktionen'].append('partner_stirbt')
-            ergebnis['partner'] = partner.name
-    
+            ergebnis["folge_aktionen"].append("partner_stirbt")
+            ergebnis["partner"] = partner.name
+
     log_eintrag(
-        spieler.raum_id,
-        f"{spieler.name} ist gestorben. (Todesart: {todesart})"
+        spieler.raum_id, f"{spieler.name} ist gestorben. (Todesart: {todesart})"
     )
-    
+
     db.session.commit()
     return ergebnis
 
@@ -534,119 +539,121 @@ def toete_spieler(spieler: Spieler, todesart: str = 'unbekannt') -> dict:
 def werwolf_abstimmung(raum: Raum) -> dict | None:
     """
     Wertet die Werwolf-Abstimmung aus.
-    
+
     Args:
         raum: Der Spielraum
-        
+
     Returns:
         Ergebnis der Abstimmung oder None
     """
     aktionen = SpielAktion.query.filter_by(
         raum_id=raum.id,
         runde=raum.runde,
-        phase='werwolf_phase',
-        aktion_typ='werwolf_wahl'
+        phase="werwolf_phase",
+        aktion_typ="werwolf_wahl",
     ).all()
-    
+
     if not aktionen:
         return None
-    
+
     # Zaehle Stimmen
     stimmen = {}
     for aktion in aktionen:
         ziel_id = aktion.ziel_spieler_id
         stimmen[ziel_id] = stimmen.get(ziel_id, 0) + 1
-    
+
     # Finde Opfer (meiste Stimmen)
     max_stimmen = max(stimmen.values())
     opfer_ids = [sid for sid, count in stimmen.items() if count == max_stimmen]
-    
+
     # Bei Gleichstand: zufaellig waehlen
     opfer_id = random.choice(opfer_ids)
     opfer = Spieler.query.get(opfer_id)
-    
+
     return {
-        'opfer_id': opfer_id,
-        'opfer_name': opfer.name if opfer else 'Unbekannt',
-        'stimmen': max_stimmen
+        "opfer_id": opfer_id,
+        "opfer_name": opfer.name if opfer else "Unbekannt",
+        "stimmen": max_stimmen,
     }
 
 
 def tag_abstimmung(raum: Raum) -> dict | None:
     """
     Wertet die Tag-Abstimmung aus.
-    
+
     Args:
         raum: Der Spielraum
-        
+
     Returns:
         Ergebnis der Abstimmung oder None
     """
     aktionen = SpielAktion.query.filter_by(
-        raum_id=raum.id,
-        runde=raum.runde,
-        phase='abstimmung',
-        aktion_typ='tag_wahl'
+        raum_id=raum.id, runde=raum.runde, phase="abstimmung", aktion_typ="tag_wahl"
     ).all()
-    
+
     if not aktionen:
         return None
-    
+
     # Zaehle Stimmen
     stimmen = {}
     for aktion in aktionen:
         ziel_id = aktion.ziel_spieler_id
         if ziel_id:  # None = Enthaltung
             stimmen[ziel_id] = stimmen.get(ziel_id, 0) + 1
-    
+
     if not stimmen:
-        return {'kein_opfer': True, 'nachricht': 'Niemand wurde gewaehlt.'}
-    
+        return {"kein_opfer": True, "nachricht": "Niemand wurde gewaehlt."}
+
     # Finde Opfer (meiste Stimmen)
     max_stimmen = max(stimmen.values())
     opfer_ids = [sid for sid, count in stimmen.items() if count == max_stimmen]
-    
+
     # Mehrheit erforderlich
-    lebende = Spieler.query.filter_by(raum_id=raum.id, ist_am_leben=True, ist_erzaehler=False).count()
+    lebende = Spieler.query.filter_by(
+        raum_id=raum.id, ist_am_leben=True, ist_erzaehler=False
+    ).count()
     if max_stimmen <= lebende // 2:
-        return {'kein_opfer': True, 'nachricht': 'Keine Mehrheit erreicht.'}
-    
+        return {"kein_opfer": True, "nachricht": "Keine Mehrheit erreicht."}
+
     # Bei Gleichstand: niemand stirbt
     if len(opfer_ids) > 1:
-        return {'kein_opfer': True, 'nachricht': 'Stimmengleichheit - niemand stirbt.'}
-    
+        return {"kein_opfer": True, "nachricht": "Stimmengleichheit - niemand stirbt."}
+
     opfer_id = opfer_ids[0]
     opfer = Spieler.query.get(opfer_id)
-    
+
     return {
-        'opfer_id': opfer_id,
-        'opfer_name': opfer.name if opfer else 'Unbekannt',
-        'opfer_rolle': opfer.rolle if opfer else 'Unbekannt',
-        'stimmen': max_stimmen
+        "opfer_id": opfer_id,
+        "opfer_name": opfer.name if opfer else "Unbekannt",
+        "opfer_rolle": opfer.rolle if opfer else "Unbekannt",
+        "stimmen": max_stimmen,
     }
 
 
-def log_eintrag(raum_id: int, nachricht: str, sichtbar_fuer: str = 'alle'):
+def log_eintrag(raum_id: int, nachricht: str, sichtbar_fuer: str = "alle"):
     """
     Erstellt einen Spiellog-Eintrag.
-    
+
     Args:
         raum_id: ID des Raums
         nachricht: Log-Nachricht
         sichtbar_fuer: Wer kann den Eintrag sehen
     """
     eintrag = SpielLog(
-        raum_id=raum_id,
-        nachricht=nachricht,
-        sichtbar_fuer=sichtbar_fuer
+        raum_id=raum_id, nachricht=nachricht, sichtbar_fuer=sichtbar_fuer
     )
     db.session.add(eintrag)
     db.session.commit()
 
 
-def registriere_aktion(raum_id: int, runde: int, phase: str, 
-                       aktion_typ: str, von_spieler_id: int, 
-                       ziel_spieler_id: int = None):
+def registriere_aktion(
+    raum_id: int,
+    runde: int,
+    phase: str,
+    aktion_typ: str,
+    von_spieler_id: int,
+    ziel_spieler_id: int = None,
+):
     """
     Registriert eine Spielaktion.
     """
@@ -656,7 +663,7 @@ def registriere_aktion(raum_id: int, runde: int, phase: str,
         phase=phase,
         aktion_typ=aktion_typ,
         von_spieler_id=von_spieler_id,
-        ziel_spieler_id=ziel_spieler_id
+        ziel_spieler_id=ziel_spieler_id,
     )
     db.session.add(aktion)
     db.session.commit()
@@ -678,9 +685,7 @@ def hole_spieler_fuer_rolle(raum: Raum, rolle: str) -> list:
     Gibt alle Spieler einer bestimmten Rolle zurueck.
     """
     return Spieler.query.filter_by(
-        raum_id=raum.id, 
-        rolle=rolle,
-        ist_am_leben=True
+        raum_id=raum.id, rolle=rolle, ist_am_leben=True
     ).all()
 
 
@@ -689,10 +694,7 @@ def hat_spieler_gewaehlt(spieler: Spieler, raum: Raum, phase: str) -> bool:
     Prueft ob ein Spieler in der aktuellen Phase bereits gewaehlt hat.
     """
     aktion = SpielAktion.query.filter_by(
-        raum_id=raum.id,
-        runde=raum.runde,
-        phase=phase,
-        von_spieler_id=spieler.id
+        raum_id=raum.id, runde=raum.runde, phase=phase, von_spieler_id=spieler.id
     ).first()
     return aktion is not None
 
@@ -705,9 +707,8 @@ def alle_haben_gewaehlt(raum: Raum, phase: str, rolle: str = None) -> bool:
         spieler = hole_spieler_fuer_rolle(raum, rolle)
     else:
         spieler = hole_lebende_spieler(raum)
-    
+
     for s in spieler:
         if not hat_spieler_gewaehlt(s, raum, phase):
             return False
     return True
-

--- a/game_logic.py
+++ b/game_logic.py
@@ -342,6 +342,7 @@ def phasennamen_zu_rollen_mapping() -> dict:
                     break
     except (ImportError, AttributeError) as exc:
         import traceback
+
         print(f"[ROLLEN] Warnung: Dynamisches Phasen-Mapping deaktiviert: {exc}")
         print(f"[ROLLEN] Traceback: {traceback.format_exc()}")
 

--- a/game_logic.py
+++ b/game_logic.py
@@ -340,8 +340,10 @@ def phasennamen_zu_rollen_mapping() -> dict:
                 if phase_key in PHASEN:
                     mapping.setdefault(phase_key, rolle.info.name)
                     break
-    except Exception as exc:
+    except (ImportError, AttributeError) as exc:
+        import traceback
         print(f"[ROLLEN] Warnung: Dynamisches Phasen-Mapping deaktiviert: {exc}")
+        print(f"[ROLLEN] Traceback: {traceback.format_exc()}")
 
     # Fallback: baue das Mapping aus dem Legacy-ROLLEN-Dict, falls die Registry
     # einmal nicht initialisiert werden konnte (z.B. in minimalen Testumgebungen).

--- a/game_logic.py
+++ b/game_logic.py
@@ -295,62 +295,58 @@ def hat_spieler_mit_rolle(raum: Raum, rolle: str) -> bool:
     return Spieler.query.filter_by(raum_id=raum.id, rolle=rolle, ist_am_leben=True).first() is not None
 
 
+def _normalisiere_phase_name(phase_name: str) -> str:
+    """Bringt dynamische Phasennamen in das PHASEN-Schema."""
+
+    replacements = {
+        'ä': 'ae',
+        'ö': 'oe',
+        'ü': 'ue',
+        'ß': 'ss',
+    }
+
+    normalisiert = phase_name.strip().lower()
+    for alt, neu in replacements.items():
+        normalisiert = normalisiert.replace(alt, neu)
+
+    normalisiert = normalisiert.replace(' ', '_')
+    while '__' in normalisiert:
+        normalisiert = normalisiert.replace('__', '_')
+    return normalisiert
+
+
 def phasennamen_zu_rollen_mapping() -> dict:
     """
-    Erstellt ein Mapping zwischen Phasennamen und erforderlichen Rollen.
-    
-    Returns:
-        Dictionary mit Phase zu Rolle Mapping
+    Erstellt ein Mapping zwischen Phasennamen und erforderlichen Rollen dynamisch
+    aus dem Rollen-Registry, so dass neue Rollen keinen Hardcode mehr benötigen.
     """
-    return {
-        'dieb_phase': 'Dieb',
-        'doppelgaenger_phase': 'Doppelgänger',
-        'armor_phase': 'Amor',
-        'priester_dunkel_phase': 'Dunkler Priester',
-        'wildes_kind_phase': 'Wildes Kind',
-        'hund_phase': 'Hund',
-        'schwestern_phase': 'Zwei Schwestern',
-        'brueder_phase': 'Drei Brüder',
-        'freimaurer_phase': 'Freimaurer',
-        'fluechtlinge_phase': 'Flüchtlinge',
-        'sandmann_phase': 'Sandmann',
-        'seherin_phase': 'Seherin',
-        'seherlehrling_phase': 'Seherlehrling',
-        'aurenseherin_phase': 'Aurenseherin',
-        'medium_phase': 'Medium',
-        'tratschweib_phase': 'Tratschweib',
-        'paranormal_billig_phase': 'Paranormaler Ermittler (billig)',
-        'werwolfseherin_phase': 'Werwolfseherin',
-        'heiler_phase': 'Heiler',
-        'leibwaechter_phase': 'Leibwächter',
-        'hure_phase': 'Hure',
-        'prostituierte_phase': 'Prostituierte',
-        'nutte_phase': 'Nutte',
-        'einsamerwolf_phase': 'Einsamer Wolf',
-        'urwolf_phase': 'Urwolf',
-        'weisser_wolf_phase': 'Weißer Wolf',
-        'mordlustiger_phase': 'Mordlustiger',
-        'hexe_phase': 'Hexe',
-        'hexenmeister_phase': 'Hexenmeister',
-        'giftmischerin_phase': 'Giftmischerin',
-        'kraeuterweib_phase': 'Kräuterweib',
-        'zauberer_phase': 'Zauberer',
-        'zahnarzt_phase': 'Zahnarzt',
-        'rabe_phase': 'Rabe',
-        'floetenspieler_phase': 'Flötenspieler',
-        'vampir_phase': 'Vampir',
-        'zombie_phase': 'Zombie',
-        'pyromane_phase': 'Pyromane',
-        'tonks_phase': 'Tonks',
-        'buddler_phase': 'Buddler',
-        'baerenbaendiger_brummen': 'Bärenbändiger',
-        'demoskopin_info': 'Demoskopin',
-        'prinz_enthuellung': 'Prinz',
-        'jaeger_phase': 'Jäger',
-        'kamikaze_phase': 'Kamikaze',
-        'hahn_enthuellung': 'Hahn',
-        'putzfrau_info': 'Putzfrau',
-    }
+
+    mapping = {}
+
+    try:
+        from roles import RoleRegistry
+
+        for rolle in RoleRegistry.get_all():
+            # Bevorzugt den von der Rolle gelieferten Namen, normalisiert ihn aber
+            # in das bestehende PHASEN-Schema (ae/oe/ue/ss statt Umlaute).
+            kandidaten = [rolle.get_phase_name(), f"{rolle.info.name}_phase"]
+            for kandidat in kandidaten:
+                phase_key = _normalisiere_phase_name(kandidat)
+                if phase_key in PHASEN:
+                    mapping.setdefault(phase_key, rolle.info.name)
+                    break
+    except Exception as exc:
+        print(f"[ROLLEN] Warnung: Dynamisches Phasen-Mapping deaktiviert: {exc}")
+
+    # Fallback: baue das Mapping aus dem Legacy-ROLLEN-Dict, falls die Registry
+    # einmal nicht initialisiert werden konnte (z.B. in minimalen Testumgebungen).
+    if not mapping:
+        for rollen_name in ROLLEN.keys():
+            phase_key = _normalisiere_phase_name(f"{rollen_name}_phase")
+            if phase_key in PHASEN:
+                mapping[phase_key] = rollen_name
+
+    return mapping
 
 
 def naechste_phase(raum: Raum) -> str:

--- a/models.py
+++ b/models.py
@@ -23,6 +23,7 @@ class Raum(db.Model):
     aktuelle_phase = db.Column(db.String(30), default='lobby')
     runde = db.Column(db.Integer, default=0)
     erzaehler_id = db.Column(db.Integer, db.ForeignKey('spieler.id'), nullable=True)
+    erzaehler_modus = db.Column(db.String(20), default='selbst')  # selbst, zufall
     
     # Spielende
     spiel_beendet = db.Column(db.Boolean, default=False)

--- a/models.py
+++ b/models.py
@@ -2,6 +2,7 @@
 Datenbankmodelle für das Webwölfe-Spiel
 Alle Rollen basierend auf: https://werwolf.fandom.com/de/wiki/Werwolf-Rollen-Sammlung
 """
+
 from flask_sqlalchemy import SQLAlchemy
 from datetime import datetime
 import secrets
@@ -11,160 +12,180 @@ db = SQLAlchemy()
 
 class Raum(db.Model):
     """Ein Spielraum/Lobby"""
-    __tablename__ = 'raeume'
-    
+
+    __tablename__ = "raeume"
+
     id = db.Column(db.Integer, primary_key=True)
     code = db.Column(db.String(6), unique=True, nullable=False, index=True)
     name = db.Column(db.String(50), nullable=False)
-    modus = db.Column(db.String(20), nullable=False, default='online')  # 'online' oder 'gruppe'
+    modus = db.Column(
+        db.String(20), nullable=False, default="online"
+    )  # 'online' oder 'gruppe'
     erstellt_am = db.Column(db.DateTime, default=datetime.utcnow)
     spieler_anzahl = db.Column(db.Integer, default=8)
     spiel_gestartet = db.Column(db.Boolean, default=False)
-    aktuelle_phase = db.Column(db.String(30), default='lobby')
+    aktuelle_phase = db.Column(db.String(30), default="lobby")
     runde = db.Column(db.Integer, default=0)
-    erzaehler_id = db.Column(db.Integer, db.ForeignKey('spieler.id'), nullable=True)
-    erzaehler_modus = db.Column(db.String(20), default='selbst')  # selbst, zufall
-    
+    erzaehler_id = db.Column(db.Integer, db.ForeignKey("spieler.id"), nullable=True)
+    erzaehler_modus = db.Column(db.String(20), default="selbst")  # selbst, zufall
+
     # Spielende
     spiel_beendet = db.Column(db.Boolean, default=False)
     gewinner = db.Column(db.String(50), nullable=True)
-    
+
     # Rollen-Konfiguration (JSON der aktivierten Rollen)
-    aktive_rollen = db.Column(db.Text, default='{}')
-    
-    spieler = db.relationship('Spieler', backref='raum', lazy=True, foreign_keys='Spieler.raum_id')
-    
+    aktive_rollen = db.Column(db.Text, default="{}")
+
+    spieler = db.relationship(
+        "Spieler", backref="raum", lazy=True, foreign_keys="Spieler.raum_id"
+    )
+
     @staticmethod
     def generiere_code():
         """Generiert einen einzigartigen 6-stelligen Raumcode"""
         while True:
-            code = ''.join(secrets.choice('ABCDEFGHJKLMNPQRSTUVWXYZ23456789') for _ in range(6))
+            code = "".join(
+                secrets.choice("ABCDEFGHJKLMNPQRSTUVWXYZ23456789") for _ in range(6)
+            )
             if not Raum.query.filter_by(code=code).first():
                 return code
 
 
 class Spieler(db.Model):
     """Ein Spieler im Spiel"""
-    __tablename__ = 'spieler'
-    
+
+    __tablename__ = "spieler"
+
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(30), nullable=False)
     session_id = db.Column(db.String(64), unique=True, nullable=False, index=True)
-    raum_id = db.Column(db.Integer, db.ForeignKey('raeume.id'), nullable=True, index=True)
+    raum_id = db.Column(
+        db.Integer, db.ForeignKey("raeume.id"), nullable=True, index=True
+    )
     rolle = db.Column(db.String(30), nullable=True, index=True)
     ist_am_leben = db.Column(db.Boolean, default=True, index=True)
     ist_erzaehler = db.Column(db.Boolean, default=False)
-    status = db.Column(db.String(20), default='wartend')  # wartend, schläft, aktiv, tot
+    status = db.Column(db.String(20), default="wartend")  # wartend, schläft, aktiv, tot
     beigetreten_am = db.Column(db.DateTime, default=datetime.utcnow)
-    
+
     # Composite indexes for common query patterns in large games
     __table_args__ = (
-        db.Index('idx_spieler_raum_leben', 'raum_id', 'ist_am_leben'),
-        db.Index('idx_spieler_raum_rolle', 'raum_id', 'rolle'),
-        db.Index('idx_spieler_raum_erzaehler', 'raum_id', 'ist_erzaehler'),
+        db.Index("idx_spieler_raum_leben", "raum_id", "ist_am_leben"),
+        db.Index("idx_spieler_raum_rolle", "raum_id", "rolle"),
+        db.Index("idx_spieler_raum_erzaehler", "raum_id", "ist_erzaehler"),
     )
-    
+
     # Sitzplatz-System für Nachbar-Mechanik und 3D-Visualisierung
     sitzplatz = db.Column(db.Integer, nullable=True)  # Position im Kreis (0-n)
     # Nachbarn werden dynamisch berechnet basierend auf sitzplatz
-    
+
     # Spezielle Fähigkeiten Status
     hexe_heiltrank = db.Column(db.Boolean, default=True)
     hexe_gifttrank = db.Column(db.Boolean, default=True)
     jaeger_schuss = db.Column(db.Boolean, default=True)
     armor_verliebt = db.Column(db.Boolean, default=True)
-    heiler_geschuetzt = db.Column(db.Integer, nullable=True)  # ID des zuletzt geschützten Spielers
-    
+    heiler_geschuetzt = db.Column(
+        db.Integer, nullable=True
+    )  # ID des zuletzt geschützten Spielers
+
     # Einmalige Fähigkeiten
     urwolf_infektion = db.Column(db.Boolean, default=True)  # Kann noch infizieren
     kamikaze_bombe = db.Column(db.Boolean, default=True)  # Kann sich noch opfern
     jesus_auferstehung = db.Column(db.Boolean, default=True)  # Kann noch auferstehen
     leibwaechter_opfer = db.Column(db.Boolean, default=True)  # Kann sich noch opfern
-    
+
     # Spezielle Rollen-Flags
     ist_infiziert = db.Column(db.Boolean, default=False)  # Urwolf-Infektion
     ist_verzaubert = db.Column(db.Boolean, default=False)  # Flötenspieler-Verzauberung
     ist_verflucht = db.Column(db.Boolean, default=False)  # Fluch (wird zum Werwolf)
-    ist_beschuetzt = db.Column(db.Boolean, default=False)  # Heiler-Schutz für diese Nacht
+    ist_beschuetzt = db.Column(
+        db.Boolean, default=False
+    )  # Heiler-Schutz für diese Nacht
     ist_stumm = db.Column(db.Boolean, default=False)  # Kräuterweib-Stummheit
     ist_vergiftet = db.Column(db.Integer, default=0)  # Giftmischerin - Tage bis Tod
     rabe_markiert = db.Column(db.Boolean, default=False)  # Rabe-Markierung
     alter_mann_leben = db.Column(db.Integer, default=2)  # Anzahl Leben
-    
+
     # Verliebt mit
-    verliebt_mit_id = db.Column(db.Integer, db.ForeignKey('spieler.id'), nullable=True)
-    
+    verliebt_mit_id = db.Column(db.Integer, db.ForeignKey("spieler.id"), nullable=True)
+
     # Vorbild (für Wildes Kind)
-    vorbild_id = db.Column(db.Integer, db.ForeignKey('spieler.id'), nullable=True)
-    
+    vorbild_id = db.Column(db.Integer, db.ForeignKey("spieler.id"), nullable=True)
+
     # Doppelgänger-Ziel
-    doppelgaenger_ziel_id = db.Column(db.Integer, db.ForeignKey('spieler.id'), nullable=True)
-    
+    doppelgaenger_ziel_id = db.Column(
+        db.Integer, db.ForeignKey("spieler.id"), nullable=True
+    )
+
     # Henker-Ziel
-    henker_ziel_id = db.Column(db.Integer, db.ForeignKey('spieler.id'), nullable=True)
-    
+    henker_ziel_id = db.Column(db.Integer, db.ForeignKey("spieler.id"), nullable=True)
+
     # Herrchen (für Hund)
-    herrchen_id = db.Column(db.Integer, db.ForeignKey('spieler.id'), nullable=True)
-    
+    herrchen_id = db.Column(db.Integer, db.ForeignKey("spieler.id"), nullable=True)
+
     # Hund hat sein Herrchen bereits gewählt
     hund_herrchen_gewaehlt = db.Column(db.Boolean, default=False)
-    
+
     @staticmethod
     def generiere_session():
         """Generiert eine einzigartige Session-ID"""
         return secrets.token_hex(32)
-    
+
     def hole_nachbar_links(self):
         """Gibt den linken Nachbarn zurück (im Uhrzeigersinn)"""
         if self.sitzplatz is None or not self.raum_id:
             return None
-        lebende_spieler = Spieler.query.filter_by(
-            raum_id=self.raum_id, 
-            ist_am_leben=True,
-            ist_erzaehler=False
-        ).order_by(Spieler.sitzplatz).all()
+        lebende_spieler = (
+            Spieler.query.filter_by(
+                raum_id=self.raum_id, ist_am_leben=True, ist_erzaehler=False
+            )
+            .order_by(Spieler.sitzplatz)
+            .all()
+        )
         if len(lebende_spieler) < 2:
             return None
-        
+
         # Finde Position in der Liste der lebenden Spieler
         eigene_position = None
         for i, s in enumerate(lebende_spieler):
             if s.id == self.id:
                 eigene_position = i
                 break
-        
+
         if eigene_position is None:
             return None
-        
+
         # Linker Nachbar (einer weniger, mit Wrap-Around)
         nachbar_pos = (eigene_position - 1) % len(lebende_spieler)
         return lebende_spieler[nachbar_pos]
-    
+
     def hole_nachbar_rechts(self):
         """Gibt den rechten Nachbarn zurück (gegen Uhrzeigersinn)"""
         if self.sitzplatz is None or not self.raum_id:
             return None
-        lebende_spieler = Spieler.query.filter_by(
-            raum_id=self.raum_id, 
-            ist_am_leben=True,
-            ist_erzaehler=False
-        ).order_by(Spieler.sitzplatz).all()
+        lebende_spieler = (
+            Spieler.query.filter_by(
+                raum_id=self.raum_id, ist_am_leben=True, ist_erzaehler=False
+            )
+            .order_by(Spieler.sitzplatz)
+            .all()
+        )
         if len(lebende_spieler) < 2:
             return None
-        
+
         eigene_position = None
         for i, s in enumerate(lebende_spieler):
             if s.id == self.id:
                 eigene_position = i
                 break
-        
+
         if eigene_position is None:
             return None
-        
+
         # Rechter Nachbar (einer mehr, mit Wrap-Around)
         nachbar_pos = (eigene_position + 1) % len(lebende_spieler)
         return lebende_spieler[nachbar_pos]
-    
+
     def hole_beide_nachbarn(self):
         """Gibt beide Nachbarn als Liste zurück"""
         nachbarn = []
@@ -179,52 +200,59 @@ class Spieler(db.Model):
 
 class SpielAktion(db.Model):
     """Aktionen während des Spiels (Abstimmungen, Tötungen, etc.)"""
-    __tablename__ = 'aktionen'
-    
+
+    __tablename__ = "aktionen"
+
     id = db.Column(db.Integer, primary_key=True)
-    raum_id = db.Column(db.Integer, db.ForeignKey('raeume.id'), nullable=False)
+    raum_id = db.Column(db.Integer, db.ForeignKey("raeume.id"), nullable=False)
     runde = db.Column(db.Integer, nullable=False)
     phase = db.Column(db.String(30), nullable=False)
     aktion_typ = db.Column(db.String(30), nullable=False)
-    von_spieler_id = db.Column(db.Integer, db.ForeignKey('spieler.id'), nullable=False)
-    ziel_spieler_id = db.Column(db.Integer, db.ForeignKey('spieler.id'), nullable=True)
+    von_spieler_id = db.Column(db.Integer, db.ForeignKey("spieler.id"), nullable=False)
+    ziel_spieler_id = db.Column(db.Integer, db.ForeignKey("spieler.id"), nullable=True)
     zusatz_daten = db.Column(db.Text, nullable=True)  # JSON für komplexe Aktionen
     zeitpunkt = db.Column(db.DateTime, default=datetime.utcnow)
-    
-    von_spieler = db.relationship('Spieler', foreign_keys=[von_spieler_id])
-    ziel_spieler = db.relationship('Spieler', foreign_keys=[ziel_spieler_id])
+
+    von_spieler = db.relationship("Spieler", foreign_keys=[von_spieler_id])
+    ziel_spieler = db.relationship("Spieler", foreign_keys=[ziel_spieler_id])
 
 
 class SpielLog(db.Model):
     """Spielverlauf-Protokoll"""
-    __tablename__ = 'spiellog'
-    
+
+    __tablename__ = "spiellog"
+
     id = db.Column(db.Integer, primary_key=True)
-    raum_id = db.Column(db.Integer, db.ForeignKey('raeume.id'), nullable=False)
+    raum_id = db.Column(db.Integer, db.ForeignKey("raeume.id"), nullable=False)
     nachricht = db.Column(db.Text, nullable=False)
     zeitpunkt = db.Column(db.DateTime, default=datetime.utcnow)
-    sichtbar_fuer = db.Column(db.String(100), default='alle')  # alle, erzähler, werwolf, spieler_id
+    sichtbar_fuer = db.Column(
+        db.String(100), default="alle"
+    )  # alle, erzähler, werwolf, spieler_id
 
 
 class ErzaehlerEvent(db.Model):
     """Tracker für einmalige Erzähler-Events (verhindert Wiederholung)"""
-    __tablename__ = 'erzaehler_events'
-    
+
+    __tablename__ = "erzaehler_events"
+
     id = db.Column(db.Integer, primary_key=True)
-    raum_id = db.Column(db.Integer, db.ForeignKey('raeume.id'), nullable=False)
-    event_typ = db.Column(db.String(50), nullable=False)  # z.B. 'amor_verliebte', 'wildes_kind_vorbild'
+    raum_id = db.Column(db.Integer, db.ForeignKey("raeume.id"), nullable=False)
+    event_typ = db.Column(
+        db.String(50), nullable=False
+    )  # z.B. 'amor_verliebte', 'wildes_kind_vorbild'
     runde = db.Column(db.Integer, nullable=True)  # In welcher Runde Event passierte
     ziel_spieler_ids = db.Column(db.String(100), nullable=True)  # Komma-getrennte IDs
     gespielt_am = db.Column(db.DateTime, default=datetime.utcnow)
-    
+
     @staticmethod
     def event_bereits_gespielt(raum_id, event_typ):
         """Prüft ob ein Event bereits gespielt wurde"""
-        return ErzaehlerEvent.query.filter_by(
-            raum_id=raum_id, 
-            event_typ=event_typ
-        ).first() is not None
-    
+        return (
+            ErzaehlerEvent.query.filter_by(raum_id=raum_id, event_typ=event_typ).first()
+            is not None
+        )
+
     @staticmethod
     def registriere_event(raum_id, event_typ, runde=None, ziel_spieler_ids=None):
         """Registriert ein gespieltes Event"""
@@ -232,7 +260,9 @@ class ErzaehlerEvent(db.Model):
             raum_id=raum_id,
             event_typ=event_typ,
             runde=runde,
-            ziel_spieler_ids=','.join(map(str, ziel_spieler_ids)) if ziel_spieler_ids else None
+            ziel_spieler_ids=(
+                ",".join(map(str, ziel_spieler_ids)) if ziel_spieler_ids else None
+            ),
         )
         db.session.add(event)
         db.session.commit()
@@ -241,17 +271,20 @@ class ErzaehlerEvent(db.Model):
 
 class SpielerPosition(db.Model):
     """3D-Position eines Spielers im Dorf (für Visualisierung)"""
-    __tablename__ = 'spieler_positionen'
-    
+
+    __tablename__ = "spieler_positionen"
+
     id = db.Column(db.Integer, primary_key=True)
-    spieler_id = db.Column(db.Integer, db.ForeignKey('spieler.id'), nullable=False, unique=True)
+    spieler_id = db.Column(
+        db.Integer, db.ForeignKey("spieler.id"), nullable=False, unique=True
+    )
     # Position im 3D-Raum (Einheitskreis um Lagerfeuer)
     winkel = db.Column(db.Float, nullable=False)  # Winkel in Grad (0-360)
     radius = db.Column(db.Float, default=5.0)  # Abstand vom Zentrum
     # Visuelle Eigenschaften
-    avatar_typ = db.Column(db.String(20), default='default')  # Charakter-Modell
-    
-    spieler = db.relationship('Spieler', backref='position_3d')
+    avatar_typ = db.Column(db.String(20), default="default")  # Charakter-Modell
+
+    spieler = db.relationship("Spieler", backref="position_3d")
 
 
 # ============================================================================
@@ -260,194 +293,193 @@ class SpielerPosition(db.Model):
 
 # PHASE-BASIERTE TEXTE (werden jede Runde wiederholt)
 ERZAEHLER_PHASEN = {
-    'nacht_start': {
-        'text': 'Das Dorf schläft ein. Alle Spieler schließen die Augen.',
-        'anweisung': 'Warte bis alle Spieler die Augen geschlossen haben.',
-        'wiederholbar': True,
+    "nacht_start": {
+        "text": "Das Dorf schläft ein. Alle Spieler schließen die Augen.",
+        "anweisung": "Warte bis alle Spieler die Augen geschlossen haben.",
+        "wiederholbar": True,
     },
-    'werwolf_phase': {
-        'text': 'Die Werwölfe erwachen. Sie erkennen sich und wählen gemeinsam ein Opfer.',
-        'anweisung': 'Die Werwölfe öffnen die Augen, schauen sich an und zeigen stumm auf ihr Opfer. Bestätige das Opfer mit einem Nicken.',
-        'wiederholbar': True,
+    "werwolf_phase": {
+        "text": "Die Werwölfe erwachen. Sie erkennen sich und wählen gemeinsam ein Opfer.",
+        "anweisung": "Die Werwölfe öffnen die Augen, schauen sich an und zeigen stumm auf ihr Opfer. Bestätige das Opfer mit einem Nicken.",
+        "wiederholbar": True,
     },
-    'seherin_phase': {
-        'text': 'Die Seherin erwacht und wählt einen Spieler, dessen Identität sie erfahren möchte.',
-        'anweisung': 'Die Seherin öffnet die Augen und zeigt auf einen Spieler. Zeige ihr mit Daumen hoch (Dorf) oder runter (Wolf) die Zugehörigkeit.',
-        'wiederholbar': True,
+    "seherin_phase": {
+        "text": "Die Seherin erwacht und wählt einen Spieler, dessen Identität sie erfahren möchte.",
+        "anweisung": "Die Seherin öffnet die Augen und zeigt auf einen Spieler. Zeige ihr mit Daumen hoch (Dorf) oder runter (Wolf) die Zugehörigkeit.",
+        "wiederholbar": True,
     },
-    'hexe_phase': {
-        'text': 'Die Hexe erwacht. Sie erfährt das Opfer der Werwölfe.',
-        'anweisung': 'Die Hexe öffnet die Augen. Zeige auf das Werwolf-Opfer. Frage mit Gesten: Heiltrank? Gifttrank?',
-        'wiederholbar': True,
+    "hexe_phase": {
+        "text": "Die Hexe erwacht. Sie erfährt das Opfer der Werwölfe.",
+        "anweisung": "Die Hexe öffnet die Augen. Zeige auf das Werwolf-Opfer. Frage mit Gesten: Heiltrank? Gifttrank?",
+        "wiederholbar": True,
     },
-    'heiler_phase': {
-        'text': 'Der Heiler erwacht und wählt einen Spieler, den er in dieser Nacht beschützen möchte.',
-        'anweisung': 'Der Heiler öffnet die Augen und zeigt auf den zu schützenden Spieler. Bestätige mit einem Nicken.',
-        'wiederholbar': True,
+    "heiler_phase": {
+        "text": "Der Heiler erwacht und wählt einen Spieler, den er in dieser Nacht beschützen möchte.",
+        "anweisung": "Der Heiler öffnet die Augen und zeigt auf den zu schützenden Spieler. Bestätige mit einem Nicken.",
+        "wiederholbar": True,
     },
-    'tag_start': {
-        'text': 'Die Sonne geht auf. Das Dorf erwacht.',
-        'anweisung': 'Alle öffnen die Augen. Verkünde die Opfer der Nacht.',
-        'wiederholbar': True,
+    "tag_start": {
+        "text": "Die Sonne geht auf. Das Dorf erwacht.",
+        "anweisung": "Alle öffnen die Augen. Verkünde die Opfer der Nacht.",
+        "wiederholbar": True,
     },
-    'diskussion': {
-        'text': 'Die Dorfbewohner diskutieren. Wer könnte ein Werwolf sein?',
-        'anweisung': 'Die Spieler diskutieren frei. Als Erzähler greifst du nur bei Regelfragen ein.',
-        'wiederholbar': True,
+    "diskussion": {
+        "text": "Die Dorfbewohner diskutieren. Wer könnte ein Werwolf sein?",
+        "anweisung": "Die Spieler diskutieren frei. Als Erzähler greifst du nur bei Regelfragen ein.",
+        "wiederholbar": True,
     },
-    'abstimmung': {
-        'text': 'Die Abstimmung beginnt. Jeder Spieler zeigt auf den Verdächtigen.',
-        'anweisung': 'Bei 3 zeigen alle gleichzeitig. Zähle die Stimmen.',
-        'wiederholbar': True,
+    "abstimmung": {
+        "text": "Die Abstimmung beginnt. Jeder Spieler zeigt auf den Verdächtigen.",
+        "anweisung": "Bei 3 zeigen alle gleichzeitig. Zähle die Stimmen.",
+        "wiederholbar": True,
     },
 }
 
 # EVENT-BASIERTE TEXTE (nur einmal pro Spiel!)
 ERZAEHLER_EVENTS = {
     # === ERSTE NACHT EVENTS (nur in Runde 1) ===
-    'erste_nacht_intro': {
-        'text': 'Willkommen in Düsterwald! Die erste Nacht bricht herein. In diesem Dorf verbergen sich Werwölfe unter den friedlichen Bewohnern.',
-        'anweisung': 'Lies diesen Text atmosphärisch vor. Dann beginne mit den Rollen.',
-        'bedingung': {'runde': 1, 'phase': 'nacht'},
-        'einmalig': True,
+    "erste_nacht_intro": {
+        "text": "Willkommen in Düsterwald! Die erste Nacht bricht herein. In diesem Dorf verbergen sich Werwölfe unter den friedlichen Bewohnern.",
+        "anweisung": "Lies diesen Text atmosphärisch vor. Dann beginne mit den Rollen.",
+        "bedingung": {"runde": 1, "phase": "nacht"},
+        "einmalig": True,
     },
-    'armor_verliebte': {
-        'text': 'Amor erwacht in dieser ersten Nacht. Er wählt zwei Spieler, die sich unsterblich verlieben werden. Ihre Schicksale sind nun für immer verbunden.',
-        'anweisung': 'Amor öffnet die Augen und zeigt auf zwei Spieler. Berühre diese leicht an der Schulter.',
-        'bedingung': {'runde': 1, 'rolle_aktiv': 'Amor'},
-        'einmalig': True,
+    "armor_verliebte": {
+        "text": "Amor erwacht in dieser ersten Nacht. Er wählt zwei Spieler, die sich unsterblich verlieben werden. Ihre Schicksale sind nun für immer verbunden.",
+        "anweisung": "Amor öffnet die Augen und zeigt auf zwei Spieler. Berühre diese leicht an der Schulter.",
+        "bedingung": {"runde": 1, "rolle_aktiv": "Amor"},
+        "einmalig": True,
     },
-    'verliebte_erfahren': {
-        'text': 'Die Verliebten erwachen kurz und erkennen einander. Sie dürfen die Augen öffnen und sich ansehen.',
-        'anweisung': 'Die beiden Verliebten öffnen kurz die Augen, lächeln sich an, und schließen sie wieder.',
-        'bedingung': {'nach_event': 'armor_verliebte'},
-        'einmalig': True,
+    "verliebte_erfahren": {
+        "text": "Die Verliebten erwachen kurz und erkennen einander. Sie dürfen die Augen öffnen und sich ansehen.",
+        "anweisung": "Die beiden Verliebten öffnen kurz die Augen, lächeln sich an, und schließen sie wieder.",
+        "bedingung": {"nach_event": "armor_verliebte"},
+        "einmalig": True,
     },
-    'wildes_kind_vorbild': {
-        'text': 'Das Wilde Kind erwacht. Es wählt ein Vorbild. Sollte dieses Vorbild sterben, wird das Kind zum Werwolf.',
-        'anweisung': 'Das Wilde Kind öffnet die Augen und zeigt auf sein Vorbild. Merke dir diese Wahl.',
-        'bedingung': {'runde': 1, 'rolle_aktiv': 'Wildes Kind'},
-        'einmalig': True,
+    "wildes_kind_vorbild": {
+        "text": "Das Wilde Kind erwacht. Es wählt ein Vorbild. Sollte dieses Vorbild sterben, wird das Kind zum Werwolf.",
+        "anweisung": "Das Wilde Kind öffnet die Augen und zeigt auf sein Vorbild. Merke dir diese Wahl.",
+        "bedingung": {"runde": 1, "rolle_aktiv": "Wildes Kind"},
+        "einmalig": True,
     },
-    'werwolf_erste_nacht': {
-        'text': 'Die Werwölfe erwachen zum ersten Mal. Sie öffnen die Augen und erkennen ihre Mitstreiter.',
-        'anweisung': 'Die Werwölfe öffnen die Augen und schauen sich an. Sie wählen noch kein Opfer - nur kennenlernen!',
-        'bedingung': {'runde': 1, 'phase': 'werwolf'},
-        'einmalig': True,
+    "werwolf_erste_nacht": {
+        "text": "Die Werwölfe erwachen zum ersten Mal. Sie öffnen die Augen und erkennen ihre Mitstreiter.",
+        "anweisung": "Die Werwölfe öffnen die Augen und schauen sich an. Sie wählen noch kein Opfer - nur kennenlernen!",
+        "bedingung": {"runde": 1, "phase": "werwolf"},
+        "einmalig": True,
     },
-    'drei_brueder_treffen': {
-        'text': 'Die drei Brüder erwachen. Sie öffnen die Augen und erkennen einander als Verbündete.',
-        'anweisung': 'Die Brüder öffnen kurz die Augen und schauen sich an.',
-        'bedingung': {'runde': 1, 'rolle_aktiv': 'Drei Brüder'},
-        'einmalig': True,
+    "drei_brueder_treffen": {
+        "text": "Die drei Brüder erwachen. Sie öffnen die Augen und erkennen einander als Verbündete.",
+        "anweisung": "Die Brüder öffnen kurz die Augen und schauen sich an.",
+        "bedingung": {"runde": 1, "rolle_aktiv": "Drei Brüder"},
+        "einmalig": True,
     },
-    'zwei_schwestern_treffen': {
-        'text': 'Die zwei Schwestern erwachen. Sie erkennen einander als Verbündete.',
-        'anweisung': 'Die Schwestern öffnen kurz die Augen und schauen sich an.',
-        'bedingung': {'runde': 1, 'rolle_aktiv': 'Zwei Schwestern'},
-        'einmalig': True,
+    "zwei_schwestern_treffen": {
+        "text": "Die zwei Schwestern erwachen. Sie erkennen einander als Verbündete.",
+        "anweisung": "Die Schwestern öffnen kurz die Augen und schauen sich an.",
+        "bedingung": {"runde": 1, "rolle_aktiv": "Zwei Schwestern"},
+        "einmalig": True,
     },
-    'freimaurer_treffen': {
-        'text': 'Die Freimaurer erwachen. Sie erkennen ihre Logenbrüder und wissen, wem sie vertrauen können.',
-        'anweisung': 'Die Freimaurer öffnen die Augen und schauen sich an.',
-        'bedingung': {'runde': 1, 'rolle_aktiv': 'Freimaurer'},
-        'einmalig': True,
+    "freimaurer_treffen": {
+        "text": "Die Freimaurer erwachen. Sie erkennen ihre Logenbrüder und wissen, wem sie vertrauen können.",
+        "anweisung": "Die Freimaurer öffnen die Augen und schauen sich an.",
+        "bedingung": {"runde": 1, "rolle_aktiv": "Freimaurer"},
+        "einmalig": True,
     },
-    'doppelgaenger_wahl': {
-        'text': 'Der Doppelgänger erwacht. Er wählt einen Spieler, dessen Rolle er übernehmen wird, sollte dieser sterben.',
-        'anweisung': 'Der Doppelgänger zeigt auf einen Spieler. Merke dir diese Wahl.',
-        'bedingung': {'runde': 1, 'rolle_aktiv': 'Doppelgänger'},
-        'einmalig': True,
+    "doppelgaenger_wahl": {
+        "text": "Der Doppelgänger erwacht. Er wählt einen Spieler, dessen Rolle er übernehmen wird, sollte dieser sterben.",
+        "anweisung": "Der Doppelgänger zeigt auf einen Spieler. Merke dir diese Wahl.",
+        "bedingung": {"runde": 1, "rolle_aktiv": "Doppelgänger"},
+        "einmalig": True,
     },
-    'hund_herrchen': {
-        'text': 'Der Hund erwacht. Er wählt sein Herrchen. Stirbt sein Herrchen, wird der Hund zum Werwolf!',
-        'anweisung': 'Der Hund öffnet die Augen und zeigt auf sein Herrchen. Merke dir diese Wahl.',
-        'bedingung': {'runde': 1, 'rolle_aktiv': 'Hund'},
-        'einmalig': True,
+    "hund_herrchen": {
+        "text": "Der Hund erwacht. Er wählt sein Herrchen. Stirbt sein Herrchen, wird der Hund zum Werwolf!",
+        "anweisung": "Der Hund öffnet die Augen und zeigt auf sein Herrchen. Merke dir diese Wahl.",
+        "bedingung": {"runde": 1, "rolle_aktiv": "Hund"},
+        "einmalig": True,
     },
-    
     # === EREIGNIS-EVENTS (passieren bei bestimmten Aktionen) ===
-    'jaeger_stirbt': {
-        'text': 'Der Jäger wurde getötet! Mit seinem letzten Atemzug greift er zur Flinte und feuert einen finalen Schuss ab!',
-        'anweisung': 'Der Jäger öffnet die Augen und zeigt auf sein Opfer. Dieses stirbt sofort.',
-        'bedingung': {'trigger': 'spieler_stirbt', 'rolle': 'Jäger'},
-        'einmalig': False,  # Kann bei mehreren Jägern mehrfach passieren
+    "jaeger_stirbt": {
+        "text": "Der Jäger wurde getötet! Mit seinem letzten Atemzug greift er zur Flinte und feuert einen finalen Schuss ab!",
+        "anweisung": "Der Jäger öffnet die Augen und zeigt auf sein Opfer. Dieses stirbt sofort.",
+        "bedingung": {"trigger": "spieler_stirbt", "rolle": "Jäger"},
+        "einmalig": False,  # Kann bei mehreren Jägern mehrfach passieren
     },
-    'hexe_heiltrank_leer': {
-        'text': 'Die Hexe hat ihren Heiltrank bereits verbraucht.',
-        'anweisung': 'Zeige der Hexe, dass sie nicht heilen kann (Kopfschütteln).',
-        'bedingung': {'trigger': 'hexe_kein_heiltrank'},
-        'einmalig': True,
+    "hexe_heiltrank_leer": {
+        "text": "Die Hexe hat ihren Heiltrank bereits verbraucht.",
+        "anweisung": "Zeige der Hexe, dass sie nicht heilen kann (Kopfschütteln).",
+        "bedingung": {"trigger": "hexe_kein_heiltrank"},
+        "einmalig": True,
     },
-    'hexe_gifttrank_leer': {
-        'text': 'Die Hexe hat ihren Gifttrank bereits verbraucht.',
-        'anweisung': 'Zeige der Hexe, dass sie nicht vergiften kann.',
-        'bedingung': {'trigger': 'hexe_kein_gifttrank'},
-        'einmalig': True,
+    "hexe_gifttrank_leer": {
+        "text": "Die Hexe hat ihren Gifttrank bereits verbraucht.",
+        "anweisung": "Zeige der Hexe, dass sie nicht vergiften kann.",
+        "bedingung": {"trigger": "hexe_kein_gifttrank"},
+        "einmalig": True,
     },
-    'urwolf_infiziert': {
-        'text': 'Der Urwolf hat sein Opfer infiziert statt getötet! Das Opfer wird zum Werwolf erwachen...',
-        'anweisung': 'Berühre das Opfer leicht - es wird in der nächsten Nacht als Werwolf erwachen.',
-        'bedingung': {'trigger': 'urwolf_infektion'},
-        'einmalig': True,
+    "urwolf_infiziert": {
+        "text": "Der Urwolf hat sein Opfer infiziert statt getötet! Das Opfer wird zum Werwolf erwachen...",
+        "anweisung": "Berühre das Opfer leicht - es wird in der nächsten Nacht als Werwolf erwachen.",
+        "bedingung": {"trigger": "urwolf_infektion"},
+        "einmalig": True,
     },
-    'wildes_kind_verwandelt': {
-        'text': 'Das Vorbild des Wilden Kindes ist gestorben! Das Kind verwandelt sich in einen Werwolf!',
-        'anweisung': 'Das Wilde Kind wird in der nächsten Nacht mit den Werwölfen aufwachen.',
-        'bedingung': {'trigger': 'vorbild_stirbt'},
-        'einmalig': True,
+    "wildes_kind_verwandelt": {
+        "text": "Das Vorbild des Wilden Kindes ist gestorben! Das Kind verwandelt sich in einen Werwolf!",
+        "anweisung": "Das Wilde Kind wird in der nächsten Nacht mit den Werwölfen aufwachen.",
+        "bedingung": {"trigger": "vorbild_stirbt"},
+        "einmalig": True,
     },
-    'hund_verwandelt': {
-        'text': 'Das Herrchen des Hundes ist gestorben! Der treue Hund verwandelt sich vor Trauer in einen Werwolf!',
-        'anweisung': 'Der Hund wird in der nächsten Nacht mit den Werwölfen aufwachen.',
-        'bedingung': {'trigger': 'herrchen_stirbt'},
-        'einmalig': True,
+    "hund_verwandelt": {
+        "text": "Das Herrchen des Hundes ist gestorben! Der treue Hund verwandelt sich vor Trauer in einen Werwolf!",
+        "anweisung": "Der Hund wird in der nächsten Nacht mit den Werwölfen aufwachen.",
+        "bedingung": {"trigger": "herrchen_stirbt"},
+        "einmalig": True,
     },
-    'jesus_aufersteht': {
-        'text': 'Jesus ist gestorben... aber wartet! Nach drei Tagen ist er wieder auferstanden!',
-        'anweisung': 'Jesus kehrt ins Spiel zurück. Ein Wunder!',
-        'bedingung': {'trigger': 'jesus_auferstehung'},
-        'einmalig': True,
+    "jesus_aufersteht": {
+        "text": "Jesus ist gestorben... aber wartet! Nach drei Tagen ist er wieder auferstanden!",
+        "anweisung": "Jesus kehrt ins Spiel zurück. Ein Wunder!",
+        "bedingung": {"trigger": "jesus_auferstehung"},
+        "einmalig": True,
     },
-    'alter_mann_stirbt_dorf': {
-        'text': 'Der Alte Mann wurde vom Dorf hingerichtet! Vor Enttäuschung verflucht er das Dorf - alle Spezialrollen verlieren ihre Fähigkeiten!',
-        'anweisung': 'Seherin, Hexe, Heiler etc. verlieren ihre Nachtaktionen.',
-        'bedingung': {'trigger': 'alter_mann_gehaengt'},
-        'einmalig': True,
+    "alter_mann_stirbt_dorf": {
+        "text": "Der Alte Mann wurde vom Dorf hingerichtet! Vor Enttäuschung verflucht er das Dorf - alle Spezialrollen verlieren ihre Fähigkeiten!",
+        "anweisung": "Seherin, Hexe, Heiler etc. verlieren ihre Nachtaktionen.",
+        "bedingung": {"trigger": "alter_mann_gehaengt"},
+        "einmalig": True,
     },
-    'pyromane_zuendet': {
-        'text': 'Der Pyromane hat ein Haus angezündet! Das Feuer breitet sich aus und tötet auch die Nachbarn!',
-        'anweisung': 'Der Pyromane und seine beiden Nachbarn sterben in den Flammen.',
-        'bedingung': {'trigger': 'pyromane_aktion'},
-        'einmalig': True,
+    "pyromane_zuendet": {
+        "text": "Der Pyromane hat ein Haus angezündet! Das Feuer breitet sich aus und tötet auch die Nachbarn!",
+        "anweisung": "Der Pyromane und seine beiden Nachbarn sterben in den Flammen.",
+        "bedingung": {"trigger": "pyromane_aktion"},
+        "einmalig": True,
     },
-    
     # === SPIELENDE EVENTS ===
-    'dorf_gewonnen': {
-        'text': 'Das Dorf hat gewonnen! Alle Werwölfe wurden eliminiert. Die Dorfbewohner können wieder in Frieden leben.',
-        'anweisung': 'Gratuliere dem Dorf! Decke alle Rollen auf.',
-        'bedingung': {'trigger': 'spielende', 'gewinner': 'dorf'},
-        'einmalig': True,
+    "dorf_gewonnen": {
+        "text": "Das Dorf hat gewonnen! Alle Werwölfe wurden eliminiert. Die Dorfbewohner können wieder in Frieden leben.",
+        "anweisung": "Gratuliere dem Dorf! Decke alle Rollen auf.",
+        "bedingung": {"trigger": "spielende", "gewinner": "dorf"},
+        "einmalig": True,
     },
-    'werwolf_gewonnen': {
-        'text': 'Die Werwölfe haben gewonnen! Sie sind nun in der Überzahl und übernehmen das Dorf.',
-        'anweisung': 'Die Werwölfe haben gewonnen. Decke alle Rollen auf.',
-        'bedingung': {'trigger': 'spielende', 'gewinner': 'werwolf'},
-        'einmalig': True,
+    "werwolf_gewonnen": {
+        "text": "Die Werwölfe haben gewonnen! Sie sind nun in der Überzahl und übernehmen das Dorf.",
+        "anweisung": "Die Werwölfe haben gewonnen. Decke alle Rollen auf.",
+        "bedingung": {"trigger": "spielende", "gewinner": "werwolf"},
+        "einmalig": True,
     },
-    'verliebte_gewonnen': {
-        'text': 'Die Verliebten haben gewonnen! Ihre Liebe hat alle Hindernisse überwunden. Sie sind die letzten Überlebenden.',
-        'anweisung': 'Die Verliebten sind die letzten Überlebenden. Romantisches Ende!',
-        'bedingung': {'trigger': 'spielende', 'gewinner': 'verliebte'},
-        'einmalig': True,
+    "verliebte_gewonnen": {
+        "text": "Die Verliebten haben gewonnen! Ihre Liebe hat alle Hindernisse überwunden. Sie sind die letzten Überlebenden.",
+        "anweisung": "Die Verliebten sind die letzten Überlebenden. Romantisches Ende!",
+        "bedingung": {"trigger": "spielende", "gewinner": "verliebte"},
+        "einmalig": True,
     },
-    'selbstmoerder_gewonnen': {
-        'text': 'Der Selbstmörder hat es geschafft! Er wurde vom Dorf hingerichtet und hat sein Ziel erreicht.',
-        'anweisung': 'Der Selbstmörder gewinnt alleine!',
-        'bedingung': {'trigger': 'spielende', 'gewinner': 'selbstmoerder'},
-        'einmalig': True,
+    "selbstmoerder_gewonnen": {
+        "text": "Der Selbstmörder hat es geschafft! Er wurde vom Dorf hingerichtet und hat sein Ziel erreicht.",
+        "anweisung": "Der Selbstmörder gewinnt alleine!",
+        "bedingung": {"trigger": "spielende", "gewinner": "selbstmoerder"},
+        "einmalig": True,
     },
 }
+
 
 # Hilfsfunktion zum Abrufen des richtigen Erzähler-Texts
 def hole_erzaehler_text(raum_id, event_typ, kontext=None):
@@ -456,27 +488,27 @@ def hole_erzaehler_text(raum_id, event_typ, kontext=None):
     kontext: Dict mit Variablen für Platzhalter (z.B. {opfer}, {spieler})
     """
     # Prüfe ob Event bereits gespielt
-    if ERZAEHLER_EVENTS.get(event_typ, {}).get('einmalig', True):
+    if ERZAEHLER_EVENTS.get(event_typ, {}).get("einmalig", True):
         if ErzaehlerEvent.event_bereits_gespielt(raum_id, event_typ):
             return None
-    
+
     event = ERZAEHLER_EVENTS.get(event_typ) or ERZAEHLER_PHASEN.get(event_typ)
     if not event:
         return None
-    
-    text = event['text']
-    anweisung = event.get('anweisung', '')
-    
+
+    text = event["text"]
+    anweisung = event.get("anweisung", "")
+
     # Platzhalter ersetzen
     if kontext:
         for key, value in kontext.items():
-            text = text.replace('{' + key + '}', str(value))
-            anweisung = anweisung.replace('{' + key + '}', str(value))
-    
+            text = text.replace("{" + key + "}", str(value))
+            anweisung = anweisung.replace("{" + key + "}", str(value))
+
     return {
-        'text': text,
-        'anweisung': anweisung,
-        'einmalig': event.get('einmalig', False),
+        "text": text,
+        "anweisung": anweisung,
+        "einmalig": event.get("einmalig", False),
     }
 
 
@@ -491,109 +523,109 @@ ERZAEHLER_TEXTE = ERZAEHLER_PHASEN
 # ============================================================================
 
 HINWEIS_TYPEN = {
-    'augen_flackern': {
-        'name': 'Augen-Flackern',
-        'beschreibung': 'Das Avatar-Bild des Spielers flackert kurz rot',
-        'dauer_ms': 150,
-        'css_class': 'hint-eyes-flicker',
-        'audio': None,
-        'verdaechtigkeit': 0.3,  # Wie verdächtig ist dieser Hinweis (0-1)
+    "augen_flackern": {
+        "name": "Augen-Flackern",
+        "beschreibung": "Das Avatar-Bild des Spielers flackert kurz rot",
+        "dauer_ms": 150,
+        "css_class": "hint-eyes-flicker",
+        "audio": None,
+        "verdaechtigkeit": 0.3,  # Wie verdächtig ist dieser Hinweis (0-1)
     },
-    'schatten': {
-        'name': 'Schatten',
-        'beschreibung': 'Ein kurzer Schatten huscht über den Spieler',
-        'dauer_ms': 300,
-        'css_class': 'hint-shadow',
-        'audio': 'shadow_swoosh.mp3',
-        'verdaechtigkeit': 0.2,
+    "schatten": {
+        "name": "Schatten",
+        "beschreibung": "Ein kurzer Schatten huscht über den Spieler",
+        "dauer_ms": 300,
+        "css_class": "hint-shadow",
+        "audio": "shadow_swoosh.mp3",
+        "verdaechtigkeit": 0.2,
     },
-    'heulen_fern': {
-        'name': 'Fernes Heulen',
-        'beschreibung': 'Ein leises, fernes Wolfsheulen ist zu hören',
-        'dauer_ms': 2000,
-        'css_class': None,
-        'audio': 'distant_howl.mp3',
-        'verdaechtigkeit': 0.4,
+    "heulen_fern": {
+        "name": "Fernes Heulen",
+        "beschreibung": "Ein leises, fernes Wolfsheulen ist zu hören",
+        "dauer_ms": 2000,
+        "css_class": None,
+        "audio": "distant_howl.mp3",
+        "verdaechtigkeit": 0.4,
     },
-    'mond_schein': {
-        'name': 'Mondschein',
-        'beschreibung': 'Mondlicht erhellt kurz den Spieler',
-        'dauer_ms': 500,
-        'css_class': 'hint-moonlight',
-        'audio': None,
-        'verdaechtigkeit': 0.25,
+    "mond_schein": {
+        "name": "Mondschein",
+        "beschreibung": "Mondlicht erhellt kurz den Spieler",
+        "dauer_ms": 500,
+        "css_class": "hint-moonlight",
+        "audio": None,
+        "verdaechtigkeit": 0.25,
     },
-    'nervoes': {
-        'name': 'Nervöses Zittern',
-        'beschreibung': 'Die Spielerkarte zittert leicht',
-        'dauer_ms': 800,
-        'css_class': 'hint-nervous',
-        'audio': None,
-        'verdaechtigkeit': 0.15,
+    "nervoes": {
+        "name": "Nervöses Zittern",
+        "beschreibung": "Die Spielerkarte zittert leicht",
+        "dauer_ms": 800,
+        "css_class": "hint-nervous",
+        "audio": None,
+        "verdaechtigkeit": 0.15,
     },
-    'blick_abwenden': {
-        'name': 'Blick abwenden',
-        'beschreibung': 'Das Avatar dreht sich kurz weg',
-        'dauer_ms': 400,
-        'css_class': 'hint-look-away',
-        'audio': None,
-        'verdaechtigkeit': 0.2,
+    "blick_abwenden": {
+        "name": "Blick abwenden",
+        "beschreibung": "Das Avatar dreht sich kurz weg",
+        "dauer_ms": 400,
+        "css_class": "hint-look-away",
+        "audio": None,
+        "verdaechtigkeit": 0.2,
     },
-    'kratzen': {
-        'name': 'Kratzen',
-        'beschreibung': 'Ein Kratzgeräusch ist zu hören',
-        'dauer_ms': 1000,
-        'css_class': None,
-        'audio': 'scratch.mp3',
-        'verdaechtigkeit': 0.35,
+    "kratzen": {
+        "name": "Kratzen",
+        "beschreibung": "Ein Kratzgeräusch ist zu hören",
+        "dauer_ms": 1000,
+        "css_class": None,
+        "audio": "scratch.mp3",
+        "verdaechtigkeit": 0.35,
     },
-    'herzschlag': {
-        'name': 'Schneller Herzschlag',
-        'beschreibung': 'Ein schneller Herzschlag pulsiert',
-        'dauer_ms': 1500,
-        'css_class': 'hint-heartbeat',
-        'audio': 'heartbeat_fast.mp3',
-        'verdaechtigkeit': 0.3,
+    "herzschlag": {
+        "name": "Schneller Herzschlag",
+        "beschreibung": "Ein schneller Herzschlag pulsiert",
+        "dauer_ms": 1500,
+        "css_class": "hint-heartbeat",
+        "audio": "heartbeat_fast.mp3",
+        "verdaechtigkeit": 0.3,
     },
-    'gluehen': {
-        'name': 'Mystisches Glühen',
-        'beschreibung': 'Ein mystisches Glühen umgibt den Spieler',
-        'dauer_ms': 600,
-        'css_class': 'hint-glow',
-        'audio': None,
-        'verdaechtigkeit': 0.1,  # Niedriger, da auch gute Rollen glühen
+    "gluehen": {
+        "name": "Mystisches Glühen",
+        "beschreibung": "Ein mystisches Glühen umgibt den Spieler",
+        "dauer_ms": 600,
+        "css_class": "hint-glow",
+        "audio": None,
+        "verdaechtigkeit": 0.1,  # Niedriger, da auch gute Rollen glühen
     },
-    'fluestern': {
-        'name': 'Flüstern',
-        'beschreibung': 'Unverständliches Flüstern ist zu hören',
-        'dauer_ms': 1200,
-        'css_class': None,
-        'audio': 'whisper.mp3',
-        'verdaechtigkeit': 0.25,
+    "fluestern": {
+        "name": "Flüstern",
+        "beschreibung": "Unverständliches Flüstern ist zu hören",
+        "dauer_ms": 1200,
+        "css_class": None,
+        "audio": "whisper.mp3",
+        "verdaechtigkeit": 0.25,
     },
-    'selbst_verdaechtigung': {
-        'name': 'Selbst-Verdächtigung',
-        'beschreibung': 'Der Spieler macht sich selbst verdächtig (Selbstmörder)',
-        'dauer_ms': 1000,
-        'css_class': 'hint-sus-self',
-        'audio': 'suspicious.mp3',
-        'verdaechtigkeit': 0.5,  # Spieler-kontrolliert
+    "selbst_verdaechtigung": {
+        "name": "Selbst-Verdächtigung",
+        "beschreibung": "Der Spieler macht sich selbst verdächtig (Selbstmörder)",
+        "dauer_ms": 1000,
+        "css_class": "hint-sus-self",
+        "audio": "suspicious.mp3",
+        "verdaechtigkeit": 0.5,  # Spieler-kontrolliert
     },
-    'stolpern': {
-        'name': 'Stolpern',
-        'beschreibung': 'Der Spieler scheint zu stolpern',
-        'dauer_ms': 500,
-        'css_class': 'hint-stumble',
-        'audio': 'stumble.mp3',
-        'verdaechtigkeit': 0.1,
+    "stolpern": {
+        "name": "Stolpern",
+        "beschreibung": "Der Spieler scheint zu stolpern",
+        "dauer_ms": 500,
+        "css_class": "hint-stumble",
+        "audio": "stumble.mp3",
+        "verdaechtigkeit": 0.1,
     },
-    'kichern': {
-        'name': 'Böses Kichern',
-        'beschreibung': 'Ein leises, böses Kichern',
-        'dauer_ms': 800,
-        'css_class': None,
-        'audio': 'evil_chuckle.mp3',
-        'verdaechtigkeit': 0.45,
+    "kichern": {
+        "name": "Böses Kichern",
+        "beschreibung": "Ein leises, böses Kichern",
+        "dauer_ms": 800,
+        "css_class": None,
+        "audio": "evil_chuckle.mp3",
+        "verdaechtigkeit": 0.45,
     },
 }
 
@@ -604,180 +636,185 @@ HINWEIS_TYPEN = {
 # ============================================================================
 
 HINWEIS_MODUS = {
-    'gruppe': {
+    "gruppe": {
         # Im Gruppen-Modus: Audio + Visual für den Erzähler
-        'audio_erlaubt': True,
-        'visual_ziel': 'erzaehler',  # Nur Erzähler sieht Hinweise
-        'synchronisiert': False,
+        "audio_erlaubt": True,
+        "visual_ziel": "erzaehler",  # Nur Erzähler sieht Hinweise
+        "synchronisiert": False,
     },
-    'online': {
+    "online": {
         # Im Online-Modus: NUR Visual, SYNCHRONISIERT für alle!
-        'audio_erlaubt': False,  # Kein Audio im Remote Play!
-        'visual_ziel': 'alle',  # Alle sehen den Hinweis gleichzeitig
-        'synchronisiert': True,  # Gleicher Timestamp für alle
-        'hinweis_nachricht': True,  # Zeige Text wie "Ein Schatten huscht über {spieler}"
+        "audio_erlaubt": False,  # Kein Audio im Remote Play!
+        "visual_ziel": "alle",  # Alle sehen den Hinweis gleichzeitig
+        "synchronisiert": True,  # Gleicher Timestamp für alle
+        "hinweis_nachricht": True,  # Zeige Text wie "Ein Schatten huscht über {spieler}"
     },
 }
 
 # Hinweis-Konfiguration pro Rollen-Team
 HINWEIS_CHANCEN = {
-    'werwolf': {
+    "werwolf": {
         # Werwölfe haben höhere Chancen, verdächtige Hinweise zu produzieren
-        'basis_chance': 0.15,  # 15% Basis-Chance pro Nachtphase
-        'hinweise': ['augen_flackern', 'schatten', 'mond_schein'],  # Nur visuelle!
-        'max_pro_nacht': 2,
+        "basis_chance": 0.15,  # 15% Basis-Chance pro Nachtphase
+        "hinweise": ["augen_flackern", "schatten", "mond_schein"],  # Nur visuelle!
+        "max_pro_nacht": 2,
     },
-    'dorf': {
+    "dorf": {
         # Dorfbewohner produzieren selten Hinweise (False Positives)
-        'basis_chance': 0.05,  # 5% Basis-Chance
-        'hinweise': ['nervoes', 'stolpern', 'gluehen'],
-        'max_pro_nacht': 1,
+        "basis_chance": 0.05,  # 5% Basis-Chance
+        "hinweise": ["nervoes", "stolpern", "gluehen"],
+        "max_pro_nacht": 1,
     },
-    'solo': {
+    "solo": {
         # Solo-Rollen haben variable Hinweise
-        'basis_chance': 0.10,
-        'hinweise': ['schatten', 'blick_abwenden', 'mond_schein'],
-        'max_pro_nacht': 1,
+        "basis_chance": 0.10,
+        "hinweise": ["schatten", "blick_abwenden", "mond_schein"],
+        "max_pro_nacht": 1,
     },
-    'neutral': {
-        'basis_chance': 0.08,
-        'hinweise': ['gluehen', 'mond_schein'],
-        'max_pro_nacht': 1,
+    "neutral": {
+        "basis_chance": 0.08,
+        "hinweise": ["gluehen", "mond_schein"],
+        "max_pro_nacht": 1,
     },
 }
 
 # Hinweise die ALLE Spieler sehen können (für Online-Synchronisation)
 SYNCHRONISIERTE_HINWEISE = {
-    'augen_flackern': {
-        'nachricht': 'Die Augen von {spieler} flackern kurz seltsam...',
-        '3d_effekt': 'eyes_glow_red',  # 3D-Visualisierung
+    "augen_flackern": {
+        "nachricht": "Die Augen von {spieler} flackern kurz seltsam...",
+        "3d_effekt": "eyes_glow_red",  # 3D-Visualisierung
     },
-    'schatten': {
-        'nachricht': 'Ein Schatten huscht über {spieler}...',
-        '3d_effekt': 'shadow_pass',
+    "schatten": {
+        "nachricht": "Ein Schatten huscht über {spieler}...",
+        "3d_effekt": "shadow_pass",
     },
-    'mond_schein': {
-        'nachricht': 'Mondlicht fällt auf {spieler}...',
-        '3d_effekt': 'moonbeam',
+    "mond_schein": {
+        "nachricht": "Mondlicht fällt auf {spieler}...",
+        "3d_effekt": "moonbeam",
     },
-    'nervoes': {
-        'nachricht': '{spieler} wirkt nervös...',
-        '3d_effekt': 'character_shake',
+    "nervoes": {
+        "nachricht": "{spieler} wirkt nervös...",
+        "3d_effekt": "character_shake",
     },
-    'stolpern': {
-        'nachricht': '{spieler} stolpert kurz...',
-        '3d_effekt': 'character_stumble',
+    "stolpern": {
+        "nachricht": "{spieler} stolpert kurz...",
+        "3d_effekt": "character_stumble",
     },
-    'gluehen': {
-        'nachricht': 'Ein mystisches Glühen umgibt {spieler}...',
-        '3d_effekt': 'aura_glow',
+    "gluehen": {
+        "nachricht": "Ein mystisches Glühen umgibt {spieler}...",
+        "3d_effekt": "aura_glow",
     },
-    'blick_abwenden': {
-        'nachricht': '{spieler} wendet den Blick ab...',
-        '3d_effekt': 'look_away',
+    "blick_abwenden": {
+        "nachricht": "{spieler} wendet den Blick ab...",
+        "3d_effekt": "look_away",
     },
-    'selbst_verdaechtigung': {
-        'nachricht': '{spieler} verhält sich verdächtig!',
-        '3d_effekt': 'suspicious_behavior',
+    "selbst_verdaechtigung": {
+        "nachricht": "{spieler} verhält sich verdächtig!",
+        "3d_effekt": "suspicious_behavior",
     },
 }
 
 # Spezielle Rollen-Hinweise (überschreiben Team-Standard)
 SPEZIAL_HINWEISE = {
-    'Selbstmörder': {
+    "Selbstmörder": {
         # Der Selbstmörder kann aktiv Hinweise auf sich ziehen!
-        'kann_hinweis_senden': True,
-        'verfuegbare_hinweise': ['selbst_verdaechtigung', 'nervoes', 'stolpern', 'blick_abwenden'],
-        'hinweise_pro_tag': 3,  # Kann 3x pro Tag sich verdächtig machen
-        'beschreibung': 'Klicke auf "Verdächtig wirken" um subtile Hinweise zu senden.',
+        "kann_hinweis_senden": True,
+        "verfuegbare_hinweise": [
+            "selbst_verdaechtigung",
+            "nervoes",
+            "stolpern",
+            "blick_abwenden",
+        ],
+        "hinweise_pro_tag": 3,  # Kann 3x pro Tag sich verdächtig machen
+        "beschreibung": 'Klicke auf "Verdächtig wirken" um subtile Hinweise zu senden.',
     },
-    'Gerber': {
-        'kann_hinweis_senden': True,
-        'verfuegbare_hinweise': ['selbst_verdaechtigung', 'nervoes'],
-        'hinweise_pro_tag': 2,
-        'beschreibung': 'Du kannst dich verdächtig machen, um gehängt zu werden.',
+    "Gerber": {
+        "kann_hinweis_senden": True,
+        "verfuegbare_hinweise": ["selbst_verdaechtigung", "nervoes"],
+        "hinweise_pro_tag": 2,
+        "beschreibung": "Du kannst dich verdächtig machen, um gehängt zu werden.",
     },
-    'Dorfdepp': {
-        'kann_hinweis_senden': True,
-        'verfuegbare_hinweise': ['stolpern', 'nervoes'],
-        'hinweise_pro_tag': 2,
-        'beschreibung': 'Mach dich zum Deppen und wirke verdächtig!',
+    "Dorfdepp": {
+        "kann_hinweis_senden": True,
+        "verfuegbare_hinweise": ["stolpern", "nervoes"],
+        "hinweise_pro_tag": 2,
+        "beschreibung": "Mach dich zum Deppen und wirke verdächtig!",
     },
-    'Engel': {
-        'kann_hinweis_senden': True,
-        'verfuegbare_hinweise': ['gluehen', 'selbst_verdaechtigung'],
-        'hinweise_pro_tag': 2,
-        'beschreibung': 'Du musst in der ersten Runde sterben! Ziehe Aufmerksamkeit auf dich.',
+    "Engel": {
+        "kann_hinweis_senden": True,
+        "verfuegbare_hinweise": ["gluehen", "selbst_verdaechtigung"],
+        "hinweise_pro_tag": 2,
+        "beschreibung": "Du musst in der ersten Runde sterben! Ziehe Aufmerksamkeit auf dich.",
     },
-    'Weißer Wolf': {
+    "Weißer Wolf": {
         # Besonders unauffällig unter Wölfen
-        'basis_chance_override': 0.08,  # Niedrigere Chance als normale Werwölfe
-        'hinweise': ['schatten'],
+        "basis_chance_override": 0.08,  # Niedrigere Chance als normale Werwölfe
+        "hinweise": ["schatten"],
     },
-    'Wolfshund': {
+    "Wolfshund": {
         # Je nach Entscheidung verschiedene Hinweise
-        'dynamisch': True,
+        "dynamisch": True,
     },
 }
 
 # Spielregeln/Varianten für Regelauswahl
 SPIEL_REGELN = {
-    'standard': {
-        'name': 'Standard-Regeln',
-        'beschreibung': 'Die klassischen Werwolf-Regeln.',
-        'einstellungen': {
-            'nacht_zeit_sekunden': 60,
-            'tag_diskussion_minuten': 5,
-            'abstimmung_zeit_sekunden': 30,
-            'tote_duerfen_reden': False,
-            'rolle_bei_tod_zeigen': True,
+    "standard": {
+        "name": "Standard-Regeln",
+        "beschreibung": "Die klassischen Werwolf-Regeln.",
+        "einstellungen": {
+            "nacht_zeit_sekunden": 60,
+            "tag_diskussion_minuten": 5,
+            "abstimmung_zeit_sekunden": 30,
+            "tote_duerfen_reden": False,
+            "rolle_bei_tod_zeigen": True,
         },
     },
-    'schnell': {
-        'name': 'Schnellspiel',
-        'beschreibung': 'Kürzere Zeiten für schnelle Runden.',
-        'einstellungen': {
-            'nacht_zeit_sekunden': 30,
-            'tag_diskussion_minuten': 2,
-            'abstimmung_zeit_sekunden': 15,
-            'tote_duerfen_reden': False,
-            'rolle_bei_tod_zeigen': True,
+    "schnell": {
+        "name": "Schnellspiel",
+        "beschreibung": "Kürzere Zeiten für schnelle Runden.",
+        "einstellungen": {
+            "nacht_zeit_sekunden": 30,
+            "tag_diskussion_minuten": 2,
+            "abstimmung_zeit_sekunden": 15,
+            "tote_duerfen_reden": False,
+            "rolle_bei_tod_zeigen": True,
         },
     },
-    'chaos': {
-        'name': 'Chaos-Modus',
-        'beschreibung': 'Mehr Zufallselemente und Überraschungen.',
-        'einstellungen': {
-            'nacht_zeit_sekunden': 45,
-            'tag_diskussion_minuten': 3,
-            'abstimmung_zeit_sekunden': 20,
-            'tote_duerfen_reden': True,  # Geister dürfen flüstern
-            'rolle_bei_tod_zeigen': False,  # Rollen bleiben geheim
-            'zufalls_ereignisse': True,
+    "chaos": {
+        "name": "Chaos-Modus",
+        "beschreibung": "Mehr Zufallselemente und Überraschungen.",
+        "einstellungen": {
+            "nacht_zeit_sekunden": 45,
+            "tag_diskussion_minuten": 3,
+            "abstimmung_zeit_sekunden": 20,
+            "tote_duerfen_reden": True,  # Geister dürfen flüstern
+            "rolle_bei_tod_zeigen": False,  # Rollen bleiben geheim
+            "zufalls_ereignisse": True,
         },
     },
-    'profi': {
-        'name': 'Profi-Modus',
-        'beschreibung': 'Für erfahrene Spieler. Weniger Hinweise, mehr Strategie.',
-        'einstellungen': {
-            'nacht_zeit_sekunden': 90,
-            'tag_diskussion_minuten': 7,
-            'abstimmung_zeit_sekunden': 45,
-            'tote_duerfen_reden': False,
-            'rolle_bei_tod_zeigen': False,
-            'hinweise_aktiviert': False,  # Keine visuellen Hinweise
+    "profi": {
+        "name": "Profi-Modus",
+        "beschreibung": "Für erfahrene Spieler. Weniger Hinweise, mehr Strategie.",
+        "einstellungen": {
+            "nacht_zeit_sekunden": 90,
+            "tag_diskussion_minuten": 7,
+            "abstimmung_zeit_sekunden": 45,
+            "tote_duerfen_reden": False,
+            "rolle_bei_tod_zeigen": False,
+            "hinweise_aktiviert": False,  # Keine visuellen Hinweise
         },
     },
-    'party': {
-        'name': 'Party-Modus',
-        'beschreibung': 'Lockere Regeln für Partys und große Gruppen.',
-        'einstellungen': {
-            'nacht_zeit_sekunden': 45,
-            'tag_diskussion_minuten': 4,
-            'abstimmung_zeit_sekunden': 20,
-            'tote_duerfen_reden': True,
-            'rolle_bei_tod_zeigen': True,
-            'mehrfach_stimmen_erlaubt': True,
+    "party": {
+        "name": "Party-Modus",
+        "beschreibung": "Lockere Regeln für Partys und große Gruppen.",
+        "einstellungen": {
+            "nacht_zeit_sekunden": 45,
+            "tag_diskussion_minuten": 4,
+            "abstimmung_zeit_sekunden": 20,
+            "tote_duerfen_reden": True,
+            "rolle_bei_tod_zeigen": True,
+            "mehrfach_stimmen_erlaubt": True,
         },
     },
 }
@@ -799,15 +836,17 @@ SPIEL_REGELN = {
 # Um eine neue Rolle hinzuzufuegen: Einfach eine .py-Datei in roles/ erstellen!
 # ============================================================================
 
+
 def _erstelle_rollen_dict():
     """
     Erstellt das ROLLEN-Dict dynamisch aus dem modularen System (roles/*.py).
-    
+
     Neue Rollen einfach als .py-Datei in roles/ hinzufuegen - sie werden
     automatisch erkannt und registriert!
     """
     try:
         from roles import get_alle_rollen
+
         return get_alle_rollen()
     except Exception as e:
         print(f"[ROLLEN] Fehler beim Laden: {e}")
@@ -820,88 +859,250 @@ ROLLEN = _erstelle_rollen_dict()
 
 # Spielphasen in korrekter Reihenfolge
 PHASEN = [
-    'lobby',
-    'rollen_verteilt',
-    'nacht_start',
+    "lobby",
+    "rollen_verteilt",
+    "nacht_start",
     # Erste-Nacht-Phasen (nur Runde 1)
-    'dieb_phase',
-    'doppelgaenger_phase',
-    'armor_phase',
-    'priester_dunkel_phase',
-    'wildes_kind_phase',
-    'hund_phase',
-    'schwestern_phase',
-    'brueder_phase',
-    'freimaurer_phase',
-    'fluechtlinge_phase',
-    'verliebte_info',
+    "dieb_phase",
+    "doppelgaenger_phase",
+    "armor_phase",
+    "priester_dunkel_phase",
+    "wildes_kind_phase",
+    "hund_phase",
+    "schwestern_phase",
+    "brueder_phase",
+    "freimaurer_phase",
+    "fluechtlinge_phase",
+    "verliebte_info",
     # Reguläre Nacht-Phasen
-    'sandmann_phase',
-    'seherin_phase',
-    'seherlehrling_phase',
-    'aurenseherin_phase',
-    'medium_phase',
-    'tratschweib_phase',
-    'paranormal_billig_phase',
-    'werwolfseherin_phase',
-    'heiler_phase',
-    'leibwaechter_phase',
-    'hure_phase',
-    'prostituierte_phase',
-    'nutte_phase',
-    'werwolf_phase',
-    'einsamerwolf_phase',
-    'urwolf_phase',
-    'weisser_wolf_phase',
-    'mordlustiger_phase',
-    'hexe_phase',
-    'hexenmeister_phase',
-    'giftmischerin_phase',
-    'kraeuterweib_phase',
-    'zauberer_phase',
-    'zahnarzt_phase',
-    'rabe_phase',
-    'floetenspieler_phase',
-    'vampir_phase',
-    'zombie_phase',
-    'pyromane_phase',
-    'tonks_phase',
-    'buddler_phase',
-    'nacht_ende',
+    "sandmann_phase",
+    "seherin_phase",
+    "seherlehrling_phase",
+    "aurenseherin_phase",
+    "medium_phase",
+    "tratschweib_phase",
+    "paranormal_billig_phase",
+    "werwolfseherin_phase",
+    "heiler_phase",
+    "leibwaechter_phase",
+    "hure_phase",
+    "prostituierte_phase",
+    "nutte_phase",
+    "werwolf_phase",
+    "einsamerwolf_phase",
+    "urwolf_phase",
+    "weisser_wolf_phase",
+    "mordlustiger_phase",
+    "hexe_phase",
+    "hexenmeister_phase",
+    "giftmischerin_phase",
+    "kraeuterweib_phase",
+    "zauberer_phase",
+    "zahnarzt_phase",
+    "rabe_phase",
+    "floetenspieler_phase",
+    "vampir_phase",
+    "zombie_phase",
+    "pyromane_phase",
+    "tonks_phase",
+    "buddler_phase",
+    "nacht_ende",
     # Tag-Phasen
-    'tag_start',
-    'baerenbaendiger_brummen',
-    'demoskopin_info',
-    'diskussion',
-    'abstimmung',
-    'abstimmung_ergebnis',
-    'prinz_enthuellung',
-    'jaeger_phase',
-    'kamikaze_phase',
-    'hahn_enthuellung',
-    'putzfrau_info',
-    'tag_ende',
-    'spiel_ende'
+    "tag_start",
+    "baerenbaendiger_brummen",
+    "demoskopin_info",
+    "diskussion",
+    "abstimmung",
+    "abstimmung_ergebnis",
+    "prinz_enthuellung",
+    "jaeger_phase",
+    "kamikaze_phase",
+    "hahn_enthuellung",
+    "putzfrau_info",
+    "tag_ende",
+    "spiel_ende",
 ]
 
 
 # Rollen-Konfiguration nach Spielerzahl (Empfehlung)
 # For games larger than defined here, use berechne_rollen() from game_logic.py
 ROLLEN_EMPFEHLUNG = {
-    5: ['Werwolf', 'Werwolf', 'Seherin', 'Dorfbewohner', 'Dorfbewohner'],
-    6: ['Werwolf', 'Werwolf', 'Seherin', 'Hexe', 'Dorfbewohner', 'Dorfbewohner'],
-    7: ['Werwolf', 'Werwolf', 'Seherin', 'Hexe', 'Jaeger', 'Dorfbewohner', 'Dorfbewohner'],
-    8: ['Werwolf', 'Werwolf', 'Seherin', 'Hexe', 'Jaeger', 'Amor', 'Dorfbewohner', 'Dorfbewohner'],
-    9: ['Werwolf', 'Werwolf', 'Seherin', 'Hexe', 'Jaeger', 'Amor', 'Heiler', 'Dorfbewohner', 'Dorfbewohner'],
-    10: ['Werwolf', 'Werwolf', 'Werwolf', 'Seherin', 'Hexe', 'Jaeger', 'Amor', 'Heiler', 'Dorfbewohner', 'Dorfbewohner'],
-    11: ['Werwolf', 'Werwolf', 'Werwolf', 'Seherin', 'Hexe', 'Jaeger', 'Amor', 'Heiler', 'Alter Mann', 'Dorfbewohner', 'Dorfbewohner'],
-    12: ['Werwolf', 'Werwolf', 'Werwolf', 'Seherin', 'Hexe', 'Jaeger', 'Amor', 'Heiler', 'Alter Mann', 'Zwei Schwestern', 'Zwei Schwestern', 'Dorfbewohner'],
-    13: ['Werwolf', 'Werwolf', 'Werwolf', 'Weisser Wolf', 'Seherin', 'Hexe', 'Jaeger', 'Amor', 'Heiler', 'Alter Mann', 'Dorfbewohner', 'Dorfbewohner', 'Dorfbewohner'],
-    14: ['Werwolf', 'Werwolf', 'Werwolf', 'Weisser Wolf', 'Seherin', 'Hexe', 'Jaeger', 'Amor', 'Heiler', 'Alter Mann', 'Medium', 'Dorfbewohner', 'Dorfbewohner', 'Dorfbewohner'],
-    15: ['Werwolf', 'Werwolf', 'Werwolf', 'Werwolf', 'Seherin', 'Hexe', 'Jaeger', 'Amor', 'Heiler', 'Alter Mann', 'Medium', 'Rabe', 'Dorfbewohner', 'Dorfbewohner', 'Dorfbewohner'],
-    16: ['Werwolf', 'Werwolf', 'Werwolf', 'Werwolf', 'Seherin', 'Hexe', 'Jaeger', 'Amor', 'Heiler', 'Alter Mann', 'Medium', 'Rabe', 'Prinz', 'Dorfbewohner', 'Dorfbewohner', 'Dorfbewohner'],
-    17: ['Werwolf', 'Werwolf', 'Werwolf', 'Werwolf', 'Urwolf', 'Seherin', 'Hexe', 'Jaeger', 'Amor', 'Heiler', 'Alter Mann', 'Medium', 'Rabe', 'Prinz', 'Dorfbewohner', 'Dorfbewohner', 'Dorfbewohner'],
-    18: ['Werwolf', 'Werwolf', 'Werwolf', 'Werwolf', 'Urwolf', 'Seherin', 'Hexe', 'Jaeger', 'Amor', 'Heiler', 'Alter Mann', 'Medium', 'Rabe', 'Prinz', 'Floetenspieler', 'Dorfbewohner', 'Dorfbewohner', 'Dorfbewohner'],
+    5: ["Werwolf", "Werwolf", "Seherin", "Dorfbewohner", "Dorfbewohner"],
+    6: ["Werwolf", "Werwolf", "Seherin", "Hexe", "Dorfbewohner", "Dorfbewohner"],
+    7: [
+        "Werwolf",
+        "Werwolf",
+        "Seherin",
+        "Hexe",
+        "Jaeger",
+        "Dorfbewohner",
+        "Dorfbewohner",
+    ],
+    8: [
+        "Werwolf",
+        "Werwolf",
+        "Seherin",
+        "Hexe",
+        "Jaeger",
+        "Amor",
+        "Dorfbewohner",
+        "Dorfbewohner",
+    ],
+    9: [
+        "Werwolf",
+        "Werwolf",
+        "Seherin",
+        "Hexe",
+        "Jaeger",
+        "Amor",
+        "Heiler",
+        "Dorfbewohner",
+        "Dorfbewohner",
+    ],
+    10: [
+        "Werwolf",
+        "Werwolf",
+        "Werwolf",
+        "Seherin",
+        "Hexe",
+        "Jaeger",
+        "Amor",
+        "Heiler",
+        "Dorfbewohner",
+        "Dorfbewohner",
+    ],
+    11: [
+        "Werwolf",
+        "Werwolf",
+        "Werwolf",
+        "Seherin",
+        "Hexe",
+        "Jaeger",
+        "Amor",
+        "Heiler",
+        "Alter Mann",
+        "Dorfbewohner",
+        "Dorfbewohner",
+    ],
+    12: [
+        "Werwolf",
+        "Werwolf",
+        "Werwolf",
+        "Seherin",
+        "Hexe",
+        "Jaeger",
+        "Amor",
+        "Heiler",
+        "Alter Mann",
+        "Zwei Schwestern",
+        "Zwei Schwestern",
+        "Dorfbewohner",
+    ],
+    13: [
+        "Werwolf",
+        "Werwolf",
+        "Werwolf",
+        "Weisser Wolf",
+        "Seherin",
+        "Hexe",
+        "Jaeger",
+        "Amor",
+        "Heiler",
+        "Alter Mann",
+        "Dorfbewohner",
+        "Dorfbewohner",
+        "Dorfbewohner",
+    ],
+    14: [
+        "Werwolf",
+        "Werwolf",
+        "Werwolf",
+        "Weisser Wolf",
+        "Seherin",
+        "Hexe",
+        "Jaeger",
+        "Amor",
+        "Heiler",
+        "Alter Mann",
+        "Medium",
+        "Dorfbewohner",
+        "Dorfbewohner",
+        "Dorfbewohner",
+    ],
+    15: [
+        "Werwolf",
+        "Werwolf",
+        "Werwolf",
+        "Werwolf",
+        "Seherin",
+        "Hexe",
+        "Jaeger",
+        "Amor",
+        "Heiler",
+        "Alter Mann",
+        "Medium",
+        "Rabe",
+        "Dorfbewohner",
+        "Dorfbewohner",
+        "Dorfbewohner",
+    ],
+    16: [
+        "Werwolf",
+        "Werwolf",
+        "Werwolf",
+        "Werwolf",
+        "Seherin",
+        "Hexe",
+        "Jaeger",
+        "Amor",
+        "Heiler",
+        "Alter Mann",
+        "Medium",
+        "Rabe",
+        "Prinz",
+        "Dorfbewohner",
+        "Dorfbewohner",
+        "Dorfbewohner",
+    ],
+    17: [
+        "Werwolf",
+        "Werwolf",
+        "Werwolf",
+        "Werwolf",
+        "Urwolf",
+        "Seherin",
+        "Hexe",
+        "Jaeger",
+        "Amor",
+        "Heiler",
+        "Alter Mann",
+        "Medium",
+        "Rabe",
+        "Prinz",
+        "Dorfbewohner",
+        "Dorfbewohner",
+        "Dorfbewohner",
+    ],
+    18: [
+        "Werwolf",
+        "Werwolf",
+        "Werwolf",
+        "Werwolf",
+        "Urwolf",
+        "Seherin",
+        "Hexe",
+        "Jaeger",
+        "Amor",
+        "Heiler",
+        "Alter Mann",
+        "Medium",
+        "Rabe",
+        "Prinz",
+        "Floetenspieler",
+        "Dorfbewohner",
+        "Dorfbewohner",
+        "Dorfbewohner",
+    ],
 }
 
 
@@ -909,87 +1110,87 @@ def berechne_balance_statistik(spieler_anzahl: int) -> dict:
     """
     Calculate balance statistics for a given player count.
     Useful for verifying game balance.
-    
+
     Args:
         spieler_anzahl: Number of players
-        
+
     Returns:
         Dictionary with balance statistics
     """
     from game_logic import berechne_rollen
-    
+
     rollen = berechne_rollen(spieler_anzahl)
-    
+
     # Calculate team sizes
     team_dorf = 0
     team_werwolf = 0
     team_solo = 0
     team_andere = 0  # Vampire, Zombie, etc.
-    
+
     for rolle_name, anzahl in rollen.items():
-        if rolle_name == 'Erzaehler':
+        if rolle_name == "Erzaehler":
             continue
         rolle_info = ROLLEN.get(rolle_name, {})
-        team = rolle_info.get('team', 'dorf')
-        
-        if team == 'dorf':
+        team = rolle_info.get("team", "dorf")
+
+        if team == "dorf":
             team_dorf += anzahl
-        elif team == 'werwolf':
+        elif team == "werwolf":
             team_werwolf += anzahl
-        elif team == 'solo':
+        elif team == "solo":
             team_solo += anzahl
         else:
             team_andere += anzahl
-    
+
     total = team_dorf + team_werwolf + team_solo + team_andere
-    
+
     return {
-        'total_players': spieler_anzahl,
-        'team_dorf': team_dorf,
-        'team_werwolf': team_werwolf,
-        'team_solo': team_solo,
-        'team_andere': team_andere,
-        'dorf_prozent': round(team_dorf / total * 100, 1) if total > 0 else 0,
-        'werwolf_prozent': round(team_werwolf / total * 100, 1) if total > 0 else 0,
-        'solo_prozent': round(team_solo / total * 100, 1) if total > 0 else 0,
-        'andere_prozent': round(team_andere / total * 100, 1) if total > 0 else 0,
-        'rollen': rollen,
-        'balance_ratio': f"1:{round(team_dorf / team_werwolf, 1) if team_werwolf > 0 else 0}" 
+        "total_players": spieler_anzahl,
+        "team_dorf": team_dorf,
+        "team_werwolf": team_werwolf,
+        "team_solo": team_solo,
+        "team_andere": team_andere,
+        "dorf_prozent": round(team_dorf / total * 100, 1) if total > 0 else 0,
+        "werwolf_prozent": round(team_werwolf / total * 100, 1) if total > 0 else 0,
+        "solo_prozent": round(team_solo / total * 100, 1) if total > 0 else 0,
+        "andere_prozent": round(team_andere / total * 100, 1) if total > 0 else 0,
+        "rollen": rollen,
+        "balance_ratio": f"1:{round(team_dorf / team_werwolf, 1) if team_werwolf > 0 else 0}",
     }
 
 
 # Teams und ihre Gewinnbedingungen
 TEAMS = {
-    'dorf': {
-        'name': 'Das Dorf',
-        'beschreibung': 'Eliminiert alle Werwölfe und andere Bedrohungen!',
-        'farbe': '#3b82f6'
+    "dorf": {
+        "name": "Das Dorf",
+        "beschreibung": "Eliminiert alle Werwölfe und andere Bedrohungen!",
+        "farbe": "#3b82f6",
     },
-    'werwolf': {
-        'name': 'Die Werwölfe',
-        'beschreibung': 'Bringt das Dorf in die Minderheit!',
-        'farbe': '#dc2626'
+    "werwolf": {
+        "name": "Die Werwölfe",
+        "beschreibung": "Bringt das Dorf in die Minderheit!",
+        "farbe": "#dc2626",
     },
-    'vampir': {
-        'name': 'Die Vampire',
-        'beschreibung': 'Verwandelt alle lebenden Spieler in Vampire!',
-        'farbe': '#7c2d12'
+    "vampir": {
+        "name": "Die Vampire",
+        "beschreibung": "Verwandelt alle lebenden Spieler in Vampire!",
+        "farbe": "#7c2d12",
     },
-    'zombie': {
-        'name': 'Die Zombies',
-        'beschreibung': 'Infiziert alle Spieler und erreicht die Mehrheit!',
-        'farbe': '#4ade80'
+    "zombie": {
+        "name": "Die Zombies",
+        "beschreibung": "Infiziert alle Spieler und erreicht die Mehrheit!",
+        "farbe": "#4ade80",
     },
-    'solo': {
-        'name': 'Einzelspieler',
-        'beschreibung': 'Erreiche dein persönliches Ziel!',
-        'farbe': '#6b7280'
+    "solo": {
+        "name": "Einzelspieler",
+        "beschreibung": "Erreiche dein persönliches Ziel!",
+        "farbe": "#6b7280",
     },
-    'verliebte': {
-        'name': 'Die Verliebten',
-        'beschreibung': 'Überlebt gemeinsam bis zum Ende!',
-        'farbe': '#ec4899'
-    }
+    "verliebte": {
+        "name": "Die Verliebten",
+        "beschreibung": "Überlebt gemeinsam bis zum Ende!",
+        "farbe": "#ec4899",
+    },
 }
 
 
@@ -998,22 +1199,23 @@ TEAMS = {
 # Diese Funktionen nutzen das dynamische ROLLEN-Dict
 # ============================================================================
 
+
 def get_rollen_nach_kategorie():
     """
     Gibt alle Rollen gruppiert nach Kategorie zurueck.
     Format: dict[kategorie][rolle_name] = rolle_data
-    
+
     Diese Funktion wird bei jedem Aufruf neu berechnet,
     um auch zur Laufzeit hinzugefuegte Rollen zu beruecksichtigen.
     """
     kategorien = {}
     rollen_dict = _erstelle_rollen_dict()  # Frisch laden
     for rolle_name, rolle_data in rollen_dict.items():
-        kat = rolle_data.get('kategorie', 'sonstige')
+        kat = rolle_data.get("kategorie", "sonstige")
         if kat not in kategorien:
             kategorien[kat] = {}
         kategorien[kat][rolle_name] = rolle_data
-    
+
     return kategorien
 
 
@@ -1026,34 +1228,31 @@ def get_rollen_nach_kategorie_liste():
     kategorien = {}
     rollen_dict = _erstelle_rollen_dict()  # Frisch laden
     for rolle_name, rolle_data in rollen_dict.items():
-        kat = rolle_data.get('kategorie', 'sonstige')
+        kat = rolle_data.get("kategorie", "sonstige")
         if kat not in kategorien:
             kategorien[kat] = []
-        kategorien[kat].append({
-            'name': rolle_name,
-            **rolle_data
-        })
-    
+        kategorien[kat].append({"name": rolle_name, **rolle_data})
+
     # Sortiere nach ID innerhalb jeder Kategorie
     for kat in kategorien:
-        kategorien[kat].sort(key=lambda x: x.get('id', 999))
-    
+        kategorien[kat].sort(key=lambda x: x.get("id", 999))
+
     return kategorien
 
 
 # Kategorienamen fuer UI (mit schoenen deutschen Namen)
 KATEGORIE_NAMEN = {
-    'grundrollen': 'Grundrollen',
-    'dorfbewohner': 'Dorfbewohner-Varianten',
-    'werwolf': 'Werwolf-Varianten',
-    'seher': 'Sehende Rollen',
-    'hexe': 'Hexen & Zauberer',
-    'jaeger': 'Jaeger & Kaempfer',
-    'heiler': 'Heiler & Beschuetzer',
-    'spezial': 'Spezialrollen',
-    'boese': 'Boese Wesen',
-    'solo': 'Einzelkaempfer',
-    'sonstige': 'Sonstige Rollen',
+    "grundrollen": "Grundrollen",
+    "dorfbewohner": "Dorfbewohner-Varianten",
+    "werwolf": "Werwolf-Varianten",
+    "seher": "Sehende Rollen",
+    "hexe": "Hexen & Zauberer",
+    "jaeger": "Jaeger & Kaempfer",
+    "heiler": "Heiler & Beschuetzer",
+    "spezial": "Spezialrollen",
+    "boese": "Boese Wesen",
+    "solo": "Einzelkaempfer",
+    "sonstige": "Sonstige Rollen",
 }
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ python-engineio>=4.8.0
 gunicorn>=21.2.0
 edge-tts>=6.1.0
 pillow>=10.0.0
+requests>=2.31.0

--- a/templates/index.html
+++ b/templates/index.html
@@ -115,13 +115,6 @@
                 </div>
                 
                 <div class="form-group">
-                    <label class="form-label">Spielerzahl (5-10000)</label>
-                    <input type="number" name="spieler_anzahl" class="form-input" 
-                           value="8" min="5" max="10000">
-                    <small class="form-hint">Für große Events: 500+ Spieler werden unterstützt!</small>
-                </div>
-                
-                <div class="form-group">
                     <label class="form-label">Spielmodus</label>
                     <select name="modus" class="form-input" id="modus-select">
                         <option value="online">Online - Jeder auf eigenem Gerät mit 3D-Dorf</option>
@@ -133,10 +126,23 @@
                 </div>
                 
                 <div class="form-group">
-                    <label class="form-checkbox">
-                        <input type="checkbox" name="ist_erzaehler">
-                        <span>Ich bin der Erzähler (spiele nicht mit)</span>
-                    </label>
+                    <label class="form-label">Wer erzählt?</label>
+                    <div class="form-radio">
+                        <label class="form-checkbox" style="margin-bottom: 0.35rem;">
+                            <input type="radio" name="erzaehler_modus" value="selbst" checked>
+                            <span>Ich erzähle selbst (klassisch, kein Glücksrad)</span>
+                        </label>
+                        <label class="form-checkbox">
+                            <input type="radio" name="erzaehler_modus" value="zufall">
+                            <span>Zufälliger Erzähler in der Lobby per Glücksrad</span>
+                        </label>
+                    </div>
+                    <small class="form-hint">Die Zufallsauswahl startet erst, wenn ihr bereit seid.</small>
+                </div>
+
+                <div class="alert alert-info" role="status" style="margin-bottom: 1rem;">
+                    <strong>Kein Vorwissen nötig!</strong> Rollen und Regeln werden automatisch erklärt,
+                    sobald der Erzähler das Spiel startet. Du musst nur deine Freunde einladen.
                 </div>
                 
                 <!-- ============================================ -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,792 +1,1198 @@
-{% extends 'struktur.html' %}
-
-{% block head %}
+{% extends 'struktur.html' %} {% block head %}
 <style>
-    .pre-alpha-modal {
-        position: fixed;
-        inset: 0;
-        display: none;
-        align-items: center;
-        justify-content: center;
-        background: rgba(10, 10, 20, 0.7);
-        z-index: 2000;
-        padding: 1.5rem;
-    }
-    .pre-alpha-modal.is-open {
-        display: flex;
-    }
-    .pre-alpha-card {
-        width: min(520px, 92vw);
-        background: var(--bg-primary);
-        border: 1px solid var(--border-color);
-        border-radius: 12px;
-        box-shadow: 0 20px 50px rgba(0, 0, 0, 0.45);
-        overflow: hidden;
-    }
-    .pre-alpha-header {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        padding: 1rem 1.25rem;
-        background: linear-gradient(135deg, rgba(196, 30, 58, 0.12), rgba(255, 193, 7, 0.12));
-        border-bottom: 1px solid var(--border-color);
-    }
-    .pre-alpha-body {
-        padding: 1rem 1.25rem;
-        color: var(--text-secondary);
-    }
-    .pre-alpha-footer {
-        padding: 0 1.25rem 1.25rem;
-        display: flex;
-        justify-content: flex-end;
-    }
-    .pre-alpha-close {
-        background: transparent;
-        border: none;
-        color: var(--text-secondary);
-        font-size: 1.25rem;
-        cursor: pointer;
-    }
+  .pre-alpha-modal {
+    position: fixed;
+    inset: 0;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    background: rgba(10, 10, 20, 0.7);
+    z-index: 2000;
+    padding: 1.5rem;
+  }
+  .pre-alpha-modal.is-open {
+    display: flex;
+  }
+  .pre-alpha-card {
+    width: min(520px, 92vw);
+    background: var(--bg-primary);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    box-shadow: 0 20px 50px rgba(0, 0, 0, 0.45);
+    overflow: hidden;
+  }
+  .pre-alpha-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem 1.25rem;
+    background: linear-gradient(
+      135deg,
+      rgba(196, 30, 58, 0.12),
+      rgba(255, 193, 7, 0.12)
+    );
+    border-bottom: 1px solid var(--border-color);
+  }
+  .pre-alpha-body {
+    padding: 1rem 1.25rem;
+    color: var(--text-secondary);
+  }
+  .pre-alpha-footer {
+    padding: 0 1.25rem 1.25rem;
+    display: flex;
+    justify-content: flex-end;
+  }
+  .pre-alpha-close {
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    font-size: 1.25rem;
+    cursor: pointer;
+  }
 </style>
-{% endblock %}
-
-{% block nav_home %}active{% endblock %}
-
-{% block content %}
+{% endblock %} {% block nav_home %}active{% endblock %} {% block content %}
 <div class="container">
-    <div class="pre-alpha-modal" id="pre-alpha-modal" role="dialog" aria-modal="true" aria-labelledby="pre-alpha-title">
-        <div class="pre-alpha-card">
-            <div class="pre-alpha-header">
-                <h5 id="pre-alpha-title" style="margin: 0; color: var(--accent-gold);">
-                    Wichtiger Hinweis: Pre-Alpha Version
-                </h5>
-                <button class="pre-alpha-close" type="button" aria-label="Close" data-close-modal>
-                    &times;
-                </button>
-            </div>
-            <div class="pre-alpha-body">
-                <p>Du benutzt eine Pre-Alpha Version von Webwölfe. Das Spiel ist noch in der Entwicklung und wird nicht funktionieren. Bitte spiele es nicht ernsthaft.</p>
-                <p>Feedback und Bug Reports sind sehr willkommen. Kontaktiere uns über GitHub.</p>
-            </div>
-            <div class="pre-alpha-footer">
-                <button type="button" class="btn btn-primary" data-close-modal>Verstanden</button>
-            </div>
-        </div>
-    </div>
-    <!-- Hero Section -->
-    <section class="hero text-center fade-in" style="padding: 4rem 0;">
-        <h1 style="font-size: 3.5rem; margin-bottom: 1rem;">
-            <span style="color: var(--accent-gold);">Web</span><span style="color: var(--accent-red);">wölfe</span>
-        </h1>
-        <p class="text-muted" style="font-size: 1.25rem; max-width: 600px; margin: 0 auto 3rem;">
-            Das klassische Werwolf-Partyspiel - jetzt digital! 
-            Entlarve die Wölfe, bevor es zu spät ist!
+  <div
+    class="pre-alpha-modal"
+    id="pre-alpha-modal"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="pre-alpha-title"
+  >
+    <div class="pre-alpha-card">
+      <div class="pre-alpha-header">
+        <h5 id="pre-alpha-title" style="margin: 0; color: var(--accent-gold)">
+          Wichtiger Hinweis: Pre-Alpha Version
+        </h5>
+        <button
+          class="pre-alpha-close"
+          type="button"
+          aria-label="Close"
+          data-close-modal
+        >
+          &times;
+        </button>
+      </div>
+      <div class="pre-alpha-body">
+        <p>
+          Du benutzt eine Pre-Alpha Version von Webwölfe. Das Spiel ist noch in
+          der Entwicklung und wird nicht funktionieren. Bitte spiele es nicht
+          ernsthaft.
         </p>
-        
-        {% if fehler %}
-        <div class="alert alert-error" style="max-width: 500px; margin: 0 auto 2rem;">
-            {{ fehler }}
-        </div>
-        {% endif %}
-    </section>
-    
-    <!-- Spielmodus Auswahl -->
-    <section class="grid grid-2 fade-in delay-1" style="max-width: 900px; margin: 0 auto;">
-        
-        <!-- Neues Spiel erstellen -->
-        <div class="card">
-            <div class="card-header">
-                <h2 style="color: var(--accent-red); font-size: 1.5rem;">
-                    <i class="fa-solid fa-paw"></i> Neues Spiel
-                </h2>
-            </div>
-            
-            <form action="{{ url_for('raum_erstellen') }}" method="POST">
-                <div class="form-group">
-                    <label class="form-label">Dein Name</label>
-                    <input type="text" name="spieler_name" class="form-input" 
-                           placeholder="Spielleiter" maxlength="30" required>
-                </div>
-                
-                <div class="form-group">
-                    <label class="form-label">Raumname</label>
-                    <input type="text" name="raum_name" class="form-input" 
-                           placeholder="Webwölfe Runde" maxlength="50">
-                </div>
-                
-                <div class="form-group">
-                    <label class="form-label">Spielmodus</label>
-                    <select name="modus" class="form-input" id="modus-select">
-                        <option value="online">Online - Jeder auf eigenem Gerät mit 3D-Dorf</option>
-                        <option value="gruppe">Gruppe - Alle zusammen vor Ort (mit Erzähler)</option>
-                    </select>
-                    <small class="form-hint" id="modus-beschreibung">
-                        Jeder Spieler verwendet sein eigenes Smartphone oder Laptop.
-                    </small>
-                </div>
-                
-                <div class="form-group">
-                    <label class="form-label">Wer erzählt?</label>
-                    <div class="form-radio">
-                        <label class="form-checkbox" style="margin-bottom: 0.35rem;">
-                            <input type="radio" name="erzaehler_modus" value="selbst" checked>
-                            <span>Ich erzähle selbst (klassisch, kein Glücksrad)</span>
-                        </label>
-                        <label class="form-checkbox">
-                            <input type="radio" name="erzaehler_modus" value="zufall">
-                            <span>Zufälliger Erzähler in der Lobby per Glücksrad</span>
-                        </label>
-                    </div>
-                    <small class="form-hint">Die Zufallsauswahl startet erst, wenn ihr bereit seid.</small>
-                </div>
-
-                <div class="alert alert-info" role="status" style="margin-bottom: 1rem;">
-                    <strong>Kein Vorwissen nötig!</strong> Rollen und Regeln werden automatisch erklärt,
-                    sobald der Erzähler das Spiel startet. Du musst nur deine Freunde einladen.
-                </div>
-                
-                <!-- ============================================ -->
-                <!-- ROLLEN-WIZARD - IMMER SICHTBAR -->
-                <!-- ============================================ -->
-                <div class="rollen-wizard" id="rollen-wizard">
-                    <div class="wizard-header">
-                        <h3><i class="fa-solid fa-masks-theater"></i> Rollen-Auswahl</h3>
-                        <p class="wizard-subtitle">Wähle die Erweiterungen für dein Spiel</p>
-                    </div>
-                    
-                    <!-- ===== BASISSPIEL ===== -->
-                    <div class="expansion-card base active" data-expansion="basis">
-                        <div class="expansion-header" onclick="toggleExpansion('basis')">
-                            <div class="expansion-title">
-                                <label class="expansion-check">
-                                    <input type="checkbox" name="expansion_basis" checked disabled>
-                                    <span class="checkmark"></span>
-                                </label>
-                                <i class="fa-solid fa-house"></i>
-                                <span>Basisspiel</span>
-                                <span class="expansion-badge required">Pflicht</span>
-                            </div>
-                            <i class="fa-solid fa-chevron-down expansion-toggle"></i>
-                        </div>
-                        <div class="expansion-content" style="display: block;">
-                            <p class="expansion-desc">Die klassischen Rollen aus dem Grundspiel</p>
-                            <div class="role-grid">
-                                <label class="role-chip evil">
-                                    <input type="checkbox" name="rollen" value="Werwolf" checked disabled>
-                                    <span><i class="fa-solid fa-paw"></i> Werwolf</span>
-                                </label>
-                                <label class="role-chip good">
-                                    <input type="checkbox" name="rollen" value="Dorfbewohner" checked disabled>
-                                    <span><i class="fa-solid fa-user"></i> Dorfbewohner</span>
-                                </label>
-                                <label class="role-chip good selected">
-                                    <input type="checkbox" name="rollen" value="Seherin" checked>
-                                    <span><i class="fa-solid fa-eye"></i> Seherin</span>
-                                </label>
-                                <label class="role-chip good">
-                                    <input type="checkbox" name="rollen" value="Hexe">
-                                    <span><i class="fa-solid fa-hat-wizard"></i> Hexe</span>
-                                </label>
-                                <label class="role-chip good">
-                                    <input type="checkbox" name="rollen" value="Jaeger">
-                                    <span><i class="fa-solid fa-crosshairs"></i> Jäger</span>
-                                </label>
-                                <label class="role-chip good">
-                                    <input type="checkbox" name="rollen" value="Amor">
-                                    <span><i class="fa-solid fa-heart"></i> Amor</span>
-                                </label>
-                                <label class="role-chip good">
-                                    <input type="checkbox" name="rollen" value="Dieb">
-                                    <span><i class="fa-solid fa-mask"></i> Dieb</span>
-                                </label>
-                                <label class="role-chip good">
-                                    <input type="checkbox" name="rollen" value="Maedchen">
-                                    <span><i class="fa-solid fa-child"></i> Mädchen</span>
-                                </label>
-                            </div>
-                        </div>
-                    </div>
-                    
-                    <!-- ===== ERWEITERUNG 1: NEUMOND ===== -->
-                    <div class="expansion-card neumond" data-expansion="neumond">
-                        <div class="expansion-header" onclick="toggleExpansion('neumond')">
-                            <div class="expansion-title">
-                                <label class="expansion-check">
-                                    <input type="checkbox" name="expansion_neumond" onchange="toggleExpansionRoles('neumond', this.checked)">
-                                    <span class="checkmark"></span>
-                                </label>
-                                <i class="fa-solid fa-moon"></i>
-                                <span>Neumond</span>
-                                <span class="expansion-badge exp1">Erw. 1</span>
-                            </div>
-                            <i class="fa-solid fa-chevron-down expansion-toggle"></i>
-                        </div>
-                        <div class="expansion-content">
-                            <p class="expansion-desc">Heiler, Alter, Sündenbock, Flötenspieler & mehr</p>
-                            <div class="role-grid">
-                                <label class="role-chip good">
-                                    <input type="checkbox" name="rollen" value="Heiler" data-exp="neumond">
-                                    <span><i class="fa-solid fa-heart-pulse"></i> Heiler</span>
-                                </label>
-                                <label class="role-chip good">
-                                    <input type="checkbox" name="rollen" value="Alter Mann" data-exp="neumond">
-                                    <span><i class="fa-solid fa-person-cane"></i> Der Alte</span>
-                                </label>
-                                <label class="role-chip good">
-                                    <input type="checkbox" name="rollen" value="Suendenbock" data-exp="neumond">
-                                    <span><i class="fa-solid fa-sheep"></i> Sündenbock</span>
-                                </label>
-                                <label class="role-chip good">
-                                    <input type="checkbox" name="rollen" value="Dorfdepp" data-exp="neumond">
-                                    <span><i class="fa-solid fa-face-grin-tongue"></i> Dorfdepp</span>
-                                </label>
-                                <label class="role-chip neutral">
-                                    <input type="checkbox" name="rollen" value="Floetenspieler" data-exp="neumond">
-                                    <span><i class="fa-solid fa-music"></i> Flötenspieler</span>
-                                </label>
-                            </div>
-                        </div>
-                    </div>
-                    
-                    <!-- ===== ERWEITERUNG 2: DIE GEMEINDE ===== -->
-                    <div class="expansion-card gemeinde" data-expansion="gemeinde">
-                        <div class="expansion-header" onclick="toggleExpansion('gemeinde')">
-                            <div class="expansion-title">
-                                <label class="expansion-check">
-                                    <input type="checkbox" name="expansion_gemeinde" onchange="toggleExpansionRoles('gemeinde', this.checked)">
-                                    <span class="checkmark"></span>
-                                </label>
-                                <i class="fa-solid fa-city"></i>
-                                <span>Die Gemeinde</span>
-                                <span class="expansion-badge exp2">Erw. 2</span>
-                            </div>
-                            <i class="fa-solid fa-chevron-down expansion-toggle"></i>
-                        </div>
-                        <div class="expansion-content">
-                            <p class="expansion-desc">Gebäude & Berufe: Brandstifter, Rabe & mehr</p>
-                            <div class="role-grid">
-                                <label class="role-chip good">
-                                    <input type="checkbox" name="rollen" value="Brandstifter" data-exp="gemeinde">
-                                    <span><i class="fa-solid fa-fire-flame-curved"></i> Brandstifter</span>
-                                </label>
-                                <label class="role-chip good">
-                                    <input type="checkbox" name="rollen" value="Rabe" data-exp="gemeinde">
-                                    <span><i class="fa-solid fa-crow"></i> Schwarzer Rabe</span>
-                                </label>
-                            </div>
-                        </div>
-                    </div>
-                    
-                    <!-- ===== ERWEITERUNG 3: CHARAKTERE ===== -->
-                    <div class="expansion-card charaktere" data-expansion="charaktere">
-                        <div class="expansion-header" onclick="toggleExpansion('charaktere')">
-                            <div class="expansion-title">
-                                <label class="expansion-check">
-                                    <input type="checkbox" name="expansion_charaktere" onchange="toggleExpansionRoles('charaktere', this.checked)">
-                                    <span class="checkmark"></span>
-                                </label>
-                                <i class="fa-solid fa-users"></i>
-                                <span>Charaktere</span>
-                                <span class="expansion-badge exp3">Erw. 3</span>
-                            </div>
-                            <i class="fa-solid fa-chevron-down expansion-toggle"></i>
-                        </div>
-                        <div class="expansion-content">
-                            <p class="expansion-desc">16 neue Rollen: Wolfsrudel, Gruppen & mehr!</p>
-                            
-                            <!-- Wölfe -->
-                            <div class="role-subcategory">
-                                <span class="subcategory-label evil"><i class="fa-solid fa-paw"></i> Wölfe</span>
-                                <div class="role-grid">
-                                    <label class="role-chip evil">
-                                        <input type="checkbox" name="rollen" value="Grosser boeser Wolf" data-exp="charaktere">
-                                        <span><i class="fa-solid fa-paw"></i> Gr. Böser Wolf</span>
-                                    </label>
-                                    <label class="role-chip evil">
-                                        <input type="checkbox" name="rollen" value="Urwolf" data-exp="charaktere">
-                                        <span><i class="fa-solid fa-paw"></i> Urwolf</span>
-                                    </label>
-                                    <label class="role-chip neutral">
-                                        <input type="checkbox" name="rollen" value="Weisser Wolf" data-exp="charaktere">
-                                        <span><i class="fa-solid fa-paw"></i> Weißer Wolf</span>
-                                    </label>
-                                    <label class="role-chip good">
-                                        <input type="checkbox" name="rollen" value="Wolfshund" data-exp="charaktere">
-                                        <span><i class="fa-solid fa-dog"></i> Wolfshund</span>
-                                    </label>
-                                    <label class="role-chip good">
-                                        <input type="checkbox" name="rollen" value="Wildes Kind" data-exp="charaktere">
-                                        <span><i class="fa-solid fa-child-reaching"></i> Wildes Kind</span>
-                                    </label>
-                                </div>
-                            </div>
-                            
-                            <!-- Dorf-Gruppen -->
-                            <div class="role-subcategory">
-                                <span class="subcategory-label good"><i class="fa-solid fa-people-group"></i> Gruppen</span>
-                                <div class="role-grid">
-                                    <label class="role-chip good">
-                                        <input type="checkbox" name="rollen" value="Zwei Schwestern" data-exp="charaktere">
-                                        <span><i class="fa-solid fa-user-group"></i> 2 Schwestern</span>
-                                    </label>
-                                    <label class="role-chip good">
-                                        <input type="checkbox" name="rollen" value="Drei Brueder" data-exp="charaktere">
-                                        <span><i class="fa-solid fa-users"></i> 3 Brüder</span>
-                                    </label>
-                                </div>
-                            </div>
-                            
-                            <!-- Spezialrollen -->
-                            <div class="role-subcategory">
-                                <span class="subcategory-label good"><i class="fa-solid fa-star"></i> Spezial</span>
-                                <div class="role-grid">
-                                    <label class="role-chip good">
-                                        <input type="checkbox" name="rollen" value="Reine Seele" data-exp="charaktere">
-                                        <span><i class="fa-solid fa-dove"></i> Reine Seele</span>
-                                    </label>
-                                    <label class="role-chip good">
-                                        <input type="checkbox" name="rollen" value="Fuchs" data-exp="charaktere">
-                                        <span><i class="fa-solid fa-paw"></i> Fuchs</span>
-                                    </label>
-                                    <label class="role-chip good">
-                                        <input type="checkbox" name="rollen" value="Ergebene Magd" data-exp="charaktere">
-                                        <span><i class="fa-solid fa-hand-holding-heart"></i> Ergebene Magd</span>
-                                    </label>
-                                    <label class="role-chip good">
-                                        <input type="checkbox" name="rollen" value="Baerenbaendiger" data-exp="charaktere">
-                                        <span><i class="fa-solid fa-hippo"></i> Bärenführer</span>
-                                    </label>
-                                    <label class="role-chip good">
-                                        <input type="checkbox" name="rollen" value="Ritter" data-exp="charaktere">
-                                        <span><i class="fa-solid fa-shield-halved"></i> Rostiger Ritter</span>
-                                    </label>
-                                    <label class="role-chip good">
-                                        <input type="checkbox" name="rollen" value="Gaukler" data-exp="charaktere">
-                                        <span><i class="fa-solid fa-masks-theater"></i> Gaukler</span>
-                                    </label>
-                                    <label class="role-chip good">
-                                        <input type="checkbox" name="rollen" value="Richter" data-exp="charaktere">
-                                        <span><i class="fa-solid fa-gavel"></i> Richter</span>
-                                    </label>
-                                </div>
-                            </div>
-                            
-                            <!-- Solo/Neutral -->
-                            <div class="role-subcategory">
-                                <span class="subcategory-label neutral"><i class="fa-solid fa-user-secret"></i> Solo</span>
-                                <div class="role-grid">
-                                    <label class="role-chip neutral">
-                                        <input type="checkbox" name="rollen" value="Engel" data-exp="charaktere">
-                                        <span><i class="fa-solid fa-feather"></i> Engel</span>
-                                    </label>
-                                    <label class="role-chip neutral">
-                                        <input type="checkbox" name="rollen" value="Verbitterter Greis" data-exp="charaktere">
-                                        <span><i class="fa-solid fa-person-cane"></i> Verb. Greis</span>
-                                    </label>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    
-                    <!-- ===== COMMUNITY ROLLEN ===== -->
-                    <div class="expansion-card community" data-expansion="community">
-                        <div class="expansion-header" onclick="toggleExpansion('community')">
-                            <div class="expansion-title">
-                                <label class="expansion-check">
-                                    <input type="checkbox" name="expansion_community" onchange="toggleExpansionRoles('community', this.checked)">
-                                    <span class="checkmark"></span>
-                                </label>
-                                <i class="fa-solid fa-puzzle-piece"></i>
-                                <span>Community-Rollen</span>
-                                <span class="expansion-badge community">Inoffiziell</span>
-                            </div>
-                            <i class="fa-solid fa-chevron-down expansion-toggle"></i>
-                        </div>
-                        <div class="expansion-content">
-                            <p class="expansion-desc">Beliebte Fan-Kreationen und Varianten</p>
-                            
-                            <!-- Böse -->
-                            <div class="role-subcategory">
-                                <span class="subcategory-label evil"><i class="fa-solid fa-skull"></i> Team Böse</span>
-                                <div class="role-grid">
-                                    <label class="role-chip evil">
-                                        <input type="checkbox" name="rollen" value="Wolfsjunge" data-exp="community">
-                                        <span><i class="fa-solid fa-baby"></i> Wolfsjunge</span>
-                                    </label>
-                                    <label class="role-chip evil">
-                                        <input type="checkbox" name="rollen" value="Wolf im Schafspelz" data-exp="community">
-                                        <span><i class="fa-solid fa-sheep"></i> Wolf im Schafspelz</span>
-                                    </label>
-                                    <label class="role-chip evil">
-                                        <input type="checkbox" name="rollen" value="Werwolfseherin" data-exp="community">
-                                        <span><i class="fa-solid fa-eye-evil"></i> Werwolf-Seherin</span>
-                                    </label>
-                                </div>
-                            </div>
-                            
-                            <!-- Gut -->
-                            <div class="role-subcategory">
-                                <span class="subcategory-label good"><i class="fa-solid fa-shield"></i> Team Dorf</span>
-                                <div class="role-grid">
-                                    <label class="role-chip good">
-                                        <input type="checkbox" name="rollen" value="Leibwaechter" data-exp="community">
-                                        <span><i class="fa-solid fa-shield"></i> Leibwächter</span>
-                                    </label>
-                                    <label class="role-chip good">
-                                        <input type="checkbox" name="rollen" value="Medium" data-exp="community">
-                                        <span><i class="fa-solid fa-ghost"></i> Medium</span>
-                                    </label>
-                                    <label class="role-chip good">
-                                        <input type="checkbox" name="rollen" value="Aurenseherin" data-exp="community">
-                                        <span><i class="fa-solid fa-sun"></i> Aura-Seherin</span>
-                                    </label>
-                                    <label class="role-chip good">
-                                        <input type="checkbox" name="rollen" value="Freimaurer" data-exp="community">
-                                        <span><i class="fa-solid fa-handshake"></i> Freimaurer</span>
-                                    </label>
-                                    <label class="role-chip good">
-                                        <input type="checkbox" name="rollen" value="Prinz" data-exp="community">
-                                        <span><i class="fa-solid fa-crown"></i> Prinz</span>
-                                    </label>
-                                    <label class="role-chip good">
-                                        <input type="checkbox" name="rollen" value="Buergermeister" data-exp="community">
-                                        <span><i class="fa-solid fa-landmark"></i> Bürgermeister</span>
-                                    </label>
-                                </div>
-                            </div>
-                            
-                            <!-- Solo/Chaos -->
-                            <div class="role-subcategory">
-                                <span class="subcategory-label neutral"><i class="fa-solid fa-dice"></i> Chaos & Solo</span>
-                                <div class="role-grid">
-                                    <label class="role-chip neutral">
-                                        <input type="checkbox" name="rollen" value="Vampir" data-exp="community">
-                                        <span><i class="fa-solid fa-teeth"></i> Vampir</span>
-                                    </label>
-                                    <label class="role-chip neutral">
-                                        <input type="checkbox" name="rollen" value="Zombie" data-exp="community">
-                                        <span><i class="fa-solid fa-biohazard"></i> Zombie</span>
-                                    </label>
-                                    <label class="role-chip neutral">
-                                        <input type="checkbox" name="rollen" value="Pyromane" data-exp="community">
-                                        <span><i class="fa-solid fa-fire"></i> Pyromane</span>
-                                    </label>
-                                    <label class="role-chip neutral">
-                                        <input type="checkbox" name="rollen" value="Doppelgaenger" data-exp="community">
-                                        <span><i class="fa-solid fa-clone"></i> Doppelgänger</span>
-                                    </label>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    
-                    <!-- Aktive Rollen Übersicht -->
-                    <div class="roles-summary" id="roles-summary">
-                        <div class="summary-header">
-                            <span><i class="fa-solid fa-list-check"></i> Aktive Rollen:</span>
-                            <span class="role-count" id="role-count">2</span>
-                        </div>
-                        <div class="roles-preview" id="roles-preview">
-                            <!-- Dynamisch gefüllt -->
-                        </div>
-                    </div>
-                </div>
-                
-                <!-- Erweiterte Einstellungen Toggle -->
-                <div class="form-group" style="margin-top: 1rem;">
-                    <button type="button" class="btn btn-ghost btn-sm" onclick="toggleErweitert()" style="width: 100%; opacity: 0.7;">
-                        <i class="fa-solid fa-cog" id="erweitert-icon"></i> Weitere Optionen
-                        <i class="fa-solid fa-chevron-down" id="erweitert-chevron"></i>
-                    </button>
-                </div>
-                
-                <!-- Erweiterte Einstellungen (versteckt) -->
-                <div id="erweiterte-einstellungen" style="display: none;">
-                    
-                    <!-- Regelset Auswahl -->
-                    <div class="form-group">
-                        <label class="form-label">Regelset</label>
-                        <select name="regelset" class="form-input">
-                            <option value="standard">Standard - Klassische Regeln</option>
-                            <option value="schnell">Schnellspiel - Kürzere Zeiten</option>
-                            <option value="chaos">Chaos - Mehr Überraschungen</option>
-                            <option value="profi">Profi - Weniger Hinweise, mehr Strategie</option>
-                            <option value="party">Party - Lockere Regeln</option>
-                        </select>
-                    </div>
-                    
-                    <!-- Hinweise aktivieren (nur Online) -->
-                    <div class="form-group" id="hinweise-option">
-                        <label class="form-checkbox">
-                            <input type="checkbox" name="hinweise_aktiv" checked>
-                            <span>Visuelle Hinweise aktivieren</span>
-                        </label>
-                    </div>
-                    
-                    <!-- Audio-Erzähler (nur Online) -->
-                    <div class="form-group" id="audio-option">
-                        <label class="form-checkbox">
-                            <input type="checkbox" name="audio_erzaehler" checked>
-                            <span>Audio-Erzähler aktivieren</span>
-                        </label>
-                    </div>
-                </div>
-                
-                <button type="submit" class="btn btn-primary btn-block btn-lg">
-                    Spiel erstellen
-                </button>
-            </form>
-        </div>
-        
-        <!-- Bestehendem Spiel beitreten -->
-        <div class="card">
-            <div class="card-header">
-                <h2 style="color: var(--accent-blue); font-size: 1.5rem;">
-                    <i class="fa-solid fa-door-open"></i> Spiel beitreten
-                </h2>
-            </div>
-            
-            <form action="{{ url_for('raum_beitreten') }}" method="POST">
-                <div class="form-group">
-                    <label class="form-label">Dein Name</label>
-                    <input type="text" name="spieler_name" class="form-input" 
-                           placeholder="Dein Name" maxlength="30" required>
+        <p>
+          Feedback und Bug Reports sind sehr willkommen. Kontaktiere uns über
+          GitHub.
+        </p>
+      </div>
+      <div class="pre-alpha-footer">
+        <button type="button" class="btn btn-primary" data-close-modal>
+          Verstanden
+        </button>
+      </div>
+    </div>
   </div>
-                
-                <div class="form-group">
-                    <label class="form-label">Raumcode</label>
-                    <input type="text" name="code" class="form-input" 
-                           placeholder="ABC123" maxlength="6" 
-                           style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 1.5rem; text-align: center;"
-                           required>
-</div>
+  <!-- Hero Section -->
+  <section class="hero text-center fade-in" style="padding: 4rem 0">
+    <h1 style="font-size: 3.5rem; margin-bottom: 1rem">
+      <span style="color: var(--accent-gold)">Web</span
+      ><span style="color: var(--accent-red)">wölfe</span>
+    </h1>
+    <p
+      class="text-muted"
+      style="font-size: 1.25rem; max-width: 600px; margin: 0 auto 3rem"
+    >
+      Das klassische Werwolf-Partyspiel - jetzt digital! Entlarve die Wölfe,
+      bevor es zu spät ist!
+    </p>
 
-                <div style="flex: 1;"></div>
-                
-                <button type="submit" class="btn btn-secondary btn-block btn-lg" style="margin-top: 2rem;">
-                    Beitreten
-                </button>
-            </form>
+    {% if fehler %}
+    <div
+      class="alert alert-error"
+      style="max-width: 500px; margin: 0 auto 2rem"
+    >
+      {{ fehler }}
+    </div>
+    {% endif %}
+  </section>
+
+  <!-- Spielmodus Auswahl -->
+  <section
+    class="grid grid-2 fade-in delay-1"
+    style="max-width: 900px; margin: 0 auto"
+  >
+    <!-- Neues Spiel erstellen -->
+    <div class="card">
+      <div class="card-header">
+        <h2 style="color: var(--accent-red); font-size: 1.5rem">
+          <i class="fa-solid fa-paw"></i> Neues Spiel
+        </h2>
+      </div>
+
+      <form action="{{ url_for('raum_erstellen') }}" method="POST">
+        <div class="form-group">
+          <label class="form-label">Dein Name</label>
+          <input
+            type="text"
+            name="spieler_name"
+            class="form-input"
+            placeholder="Spielleiter"
+            maxlength="30"
+            required
+          />
         </div>
-    </section>
-    
-    <!-- Spielanleitung -->
-    <section class="fade-in delay-2" style="max-width: 900px; margin: 4rem auto 0;">
-        <div class="card">
-            <h3 style="color: var(--accent-gold); margin-bottom: 1.5rem;">Wie funktioniert es?</h3>
-            
-            <div class="grid grid-3" style="text-align: center;">
-                <div>
-                    <div style="font-size: 2.5rem; margin-bottom: 0.5rem; color: var(--accent-gold);">
-                        <i class="fa-solid fa-plus-circle"></i>
-                    </div>
-                    <h4 class="mb-1">Raum erstellen</h4>
-                    <p class="text-muted">Erstelle einen Raum und teile den Code mit deinen Freunden.</p>
+
+        <div class="form-group">
+          <label class="form-label">Raumname</label>
+          <input
+            type="text"
+            name="raum_name"
+            class="form-input"
+            placeholder="Webwölfe Runde"
+            maxlength="50"
+          />
+        </div>
+
+        <div class="form-group">
+          <label class="form-label">Spielmodus</label>
+          <select name="modus" class="form-input" id="modus-select">
+            <option value="online">
+              Online - Jeder auf eigenem Gerät mit 3D-Dorf
+            </option>
+            <option value="gruppe">
+              Gruppe - Alle zusammen vor Ort (mit Erzähler)
+            </option>
+          </select>
+          <small class="form-hint" id="modus-beschreibung">
+            Jeder Spieler verwendet sein eigenes Smartphone oder Laptop.
+          </small>
+        </div>
+
+        <div class="form-group">
+          <label class="form-label">Wer erzählt?</label>
+          <div class="form-radio">
+            <label class="form-checkbox" style="margin-bottom: 0.35rem">
+              <input
+                type="radio"
+                name="erzaehler_modus"
+                value="selbst"
+                checked
+              />
+              <span>Ich erzähle selbst (klassisch, kein Glücksrad)</span>
+            </label>
+            <label class="form-checkbox">
+              <input type="radio" name="erzaehler_modus" value="zufall" />
+              <span>Zufälliger Erzähler in der Lobby per Glücksrad</span>
+            </label>
+          </div>
+          <small class="form-hint"
+            >Die Zufallsauswahl startet erst, wenn ihr bereit seid.</small
+          >
+        </div>
+
+        <div class="alert alert-info" role="status" style="margin-bottom: 1rem">
+          <strong>Kein Vorwissen nötig!</strong> Rollen und Regeln werden
+          automatisch erklärt, sobald der Erzähler das Spiel startet. Du musst
+          nur deine Freunde einladen.
+        </div>
+
+        <!-- ============================================ -->
+        <!-- ROLLEN-WIZARD - IMMER SICHTBAR -->
+        <!-- ============================================ -->
+        <div class="rollen-wizard" id="rollen-wizard">
+          <div class="wizard-header">
+            <h3><i class="fa-solid fa-masks-theater"></i> Rollen-Auswahl</h3>
+            <p class="wizard-subtitle">
+              Wähle die Erweiterungen für dein Spiel
+            </p>
+          </div>
+
+          <!-- ===== BASISSPIEL ===== -->
+          <div class="expansion-card base active" data-expansion="basis">
+            <div class="expansion-header" onclick="toggleExpansion('basis')">
+              <div class="expansion-title">
+                <label class="expansion-check">
+                  <input
+                    type="checkbox"
+                    name="expansion_basis"
+                    checked
+                    disabled
+                  />
+                  <span class="checkmark"></span>
+                </label>
+                <i class="fa-solid fa-house"></i>
+                <span>Basisspiel</span>
+                <span class="expansion-badge required">Pflicht</span>
+              </div>
+              <i class="fa-solid fa-chevron-down expansion-toggle"></i>
+            </div>
+            <div class="expansion-content" style="display: block">
+              <p class="expansion-desc">
+                Die klassischen Rollen aus dem Grundspiel
+              </p>
+              <div class="role-grid">
+                <label class="role-chip evil">
+                  <input
+                    type="checkbox"
+                    name="rollen"
+                    value="Werwolf"
+                    checked
+                    disabled
+                  />
+                  <span><i class="fa-solid fa-paw"></i> Werwolf</span>
+                </label>
+                <label class="role-chip good">
+                  <input
+                    type="checkbox"
+                    name="rollen"
+                    value="Dorfbewohner"
+                    checked
+                    disabled
+                  />
+                  <span><i class="fa-solid fa-user"></i> Dorfbewohner</span>
+                </label>
+                <label class="role-chip good selected">
+                  <input
+                    type="checkbox"
+                    name="rollen"
+                    value="Seherin"
+                    checked
+                  />
+                  <span><i class="fa-solid fa-eye"></i> Seherin</span>
+                </label>
+                <label class="role-chip good">
+                  <input type="checkbox" name="rollen" value="Hexe" />
+                  <span><i class="fa-solid fa-hat-wizard"></i> Hexe</span>
+                </label>
+                <label class="role-chip good">
+                  <input type="checkbox" name="rollen" value="Jaeger" />
+                  <span><i class="fa-solid fa-crosshairs"></i> Jäger</span>
+                </label>
+                <label class="role-chip good">
+                  <input type="checkbox" name="rollen" value="Amor" />
+                  <span><i class="fa-solid fa-heart"></i> Amor</span>
+                </label>
+                <label class="role-chip good">
+                  <input type="checkbox" name="rollen" value="Dieb" />
+                  <span><i class="fa-solid fa-mask"></i> Dieb</span>
+                </label>
+                <label class="role-chip good">
+                  <input type="checkbox" name="rollen" value="Maedchen" />
+                  <span><i class="fa-solid fa-child"></i> Mädchen</span>
+                </label>
+              </div>
+            </div>
+          </div>
+
+          <!-- ===== ERWEITERUNG 1: NEUMOND ===== -->
+          <div class="expansion-card neumond" data-expansion="neumond">
+            <div class="expansion-header" onclick="toggleExpansion('neumond')">
+              <div class="expansion-title">
+                <label class="expansion-check">
+                  <input
+                    type="checkbox"
+                    name="expansion_neumond"
+                    onchange="toggleExpansionRoles('neumond', this.checked)"
+                  />
+                  <span class="checkmark"></span>
+                </label>
+                <i class="fa-solid fa-moon"></i>
+                <span>Neumond</span>
+                <span class="expansion-badge exp1">Erw. 1</span>
+              </div>
+              <i class="fa-solid fa-chevron-down expansion-toggle"></i>
+            </div>
+            <div class="expansion-content">
+              <p class="expansion-desc">
+                Heiler, Alter, Sündenbock, Flötenspieler & mehr
+              </p>
+              <div class="role-grid">
+                <label class="role-chip good">
+                  <input
+                    type="checkbox"
+                    name="rollen"
+                    value="Heiler"
+                    data-exp="neumond"
+                  />
+                  <span><i class="fa-solid fa-heart-pulse"></i> Heiler</span>
+                </label>
+                <label class="role-chip good">
+                  <input
+                    type="checkbox"
+                    name="rollen"
+                    value="Alter Mann"
+                    data-exp="neumond"
+                  />
+                  <span><i class="fa-solid fa-person-cane"></i> Der Alte</span>
+                </label>
+                <label class="role-chip good">
+                  <input
+                    type="checkbox"
+                    name="rollen"
+                    value="Suendenbock"
+                    data-exp="neumond"
+                  />
+                  <span><i class="fa-solid fa-sheep"></i> Sündenbock</span>
+                </label>
+                <label class="role-chip good">
+                  <input
+                    type="checkbox"
+                    name="rollen"
+                    value="Dorfdepp"
+                    data-exp="neumond"
+                  />
+                  <span
+                    ><i class="fa-solid fa-face-grin-tongue"></i> Dorfdepp</span
+                  >
+                </label>
+                <label class="role-chip neutral">
+                  <input
+                    type="checkbox"
+                    name="rollen"
+                    value="Floetenspieler"
+                    data-exp="neumond"
+                  />
+                  <span><i class="fa-solid fa-music"></i> Flötenspieler</span>
+                </label>
+              </div>
+            </div>
+          </div>
+
+          <!-- ===== ERWEITERUNG 2: DIE GEMEINDE ===== -->
+          <div class="expansion-card gemeinde" data-expansion="gemeinde">
+            <div class="expansion-header" onclick="toggleExpansion('gemeinde')">
+              <div class="expansion-title">
+                <label class="expansion-check">
+                  <input
+                    type="checkbox"
+                    name="expansion_gemeinde"
+                    onchange="toggleExpansionRoles('gemeinde', this.checked)"
+                  />
+                  <span class="checkmark"></span>
+                </label>
+                <i class="fa-solid fa-city"></i>
+                <span>Die Gemeinde</span>
+                <span class="expansion-badge exp2">Erw. 2</span>
+              </div>
+              <i class="fa-solid fa-chevron-down expansion-toggle"></i>
+            </div>
+            <div class="expansion-content">
+              <p class="expansion-desc">
+                Gebäude & Berufe: Brandstifter, Rabe & mehr
+              </p>
+              <div class="role-grid">
+                <label class="role-chip good">
+                  <input
+                    type="checkbox"
+                    name="rollen"
+                    value="Brandstifter"
+                    data-exp="gemeinde"
+                  />
+                  <span
+                    ><i class="fa-solid fa-fire-flame-curved"></i>
+                    Brandstifter</span
+                  >
+                </label>
+                <label class="role-chip good">
+                  <input
+                    type="checkbox"
+                    name="rollen"
+                    value="Rabe"
+                    data-exp="gemeinde"
+                  />
+                  <span><i class="fa-solid fa-crow"></i> Schwarzer Rabe</span>
+                </label>
+              </div>
+            </div>
+          </div>
+
+          <!-- ===== ERWEITERUNG 3: CHARAKTERE ===== -->
+          <div class="expansion-card charaktere" data-expansion="charaktere">
+            <div
+              class="expansion-header"
+              onclick="toggleExpansion('charaktere')"
+            >
+              <div class="expansion-title">
+                <label class="expansion-check">
+                  <input
+                    type="checkbox"
+                    name="expansion_charaktere"
+                    onchange="toggleExpansionRoles('charaktere', this.checked)"
+                  />
+                  <span class="checkmark"></span>
+                </label>
+                <i class="fa-solid fa-users"></i>
+                <span>Charaktere</span>
+                <span class="expansion-badge exp3">Erw. 3</span>
+              </div>
+              <i class="fa-solid fa-chevron-down expansion-toggle"></i>
+            </div>
+            <div class="expansion-content">
+              <p class="expansion-desc">
+                16 neue Rollen: Wolfsrudel, Gruppen & mehr!
+              </p>
+
+              <!-- Wölfe -->
+              <div class="role-subcategory">
+                <span class="subcategory-label evil"
+                  ><i class="fa-solid fa-paw"></i> Wölfe</span
+                >
+                <div class="role-grid">
+                  <label class="role-chip evil">
+                    <input
+                      type="checkbox"
+                      name="rollen"
+                      value="Grosser boeser Wolf"
+                      data-exp="charaktere"
+                    />
+                    <span><i class="fa-solid fa-paw"></i> Gr. Böser Wolf</span>
+                  </label>
+                  <label class="role-chip evil">
+                    <input
+                      type="checkbox"
+                      name="rollen"
+                      value="Urwolf"
+                      data-exp="charaktere"
+                    />
+                    <span><i class="fa-solid fa-paw"></i> Urwolf</span>
+                  </label>
+                  <label class="role-chip neutral">
+                    <input
+                      type="checkbox"
+                      name="rollen"
+                      value="Weisser Wolf"
+                      data-exp="charaktere"
+                    />
+                    <span><i class="fa-solid fa-paw"></i> Weißer Wolf</span>
+                  </label>
+                  <label class="role-chip good">
+                    <input
+                      type="checkbox"
+                      name="rollen"
+                      value="Wolfshund"
+                      data-exp="charaktere"
+                    />
+                    <span><i class="fa-solid fa-dog"></i> Wolfshund</span>
+                  </label>
+                  <label class="role-chip good">
+                    <input
+                      type="checkbox"
+                      name="rollen"
+                      value="Wildes Kind"
+                      data-exp="charaktere"
+                    />
+                    <span
+                      ><i class="fa-solid fa-child-reaching"></i> Wildes
+                      Kind</span
+                    >
+                  </label>
                 </div>
-                <div>
-                    <div style="font-size: 2.5rem; margin-bottom: 0.5rem; color: var(--accent-blue);">
-                        <i class="fa-solid fa-user-secret"></i>
-                    </div>
-                    <h4 class="mb-1">Rollen erhalten</h4>
-                    <p class="text-muted">Jeder Spieler bekommt eine geheime Rolle zugewiesen.</p>
+              </div>
+
+              <!-- Dorf-Gruppen -->
+              <div class="role-subcategory">
+                <span class="subcategory-label good"
+                  ><i class="fa-solid fa-people-group"></i> Gruppen</span
+                >
+                <div class="role-grid">
+                  <label class="role-chip good">
+                    <input
+                      type="checkbox"
+                      name="rollen"
+                      value="Zwei Schwestern"
+                      data-exp="charaktere"
+                    />
+                    <span
+                      ><i class="fa-solid fa-user-group"></i> 2 Schwestern</span
+                    >
+                  </label>
+                  <label class="role-chip good">
+                    <input
+                      type="checkbox"
+                      name="rollen"
+                      value="Drei Brueder"
+                      data-exp="charaktere"
+                    />
+                    <span><i class="fa-solid fa-users"></i> 3 Brüder</span>
+                  </label>
                 </div>
-                <div>
-                    <div style="font-size: 2.5rem; margin-bottom: 0.5rem; color: var(--accent-red);">
-                        <i class="fa-solid fa-gamepad"></i>
-                    </div>
-                    <h4 class="mb-1">Spielen!</h4>
-                    <p class="text-muted">Entlarve die Werwölfe oder eliminiere das Dorf.</p>
+              </div>
+
+              <!-- Spezialrollen -->
+              <div class="role-subcategory">
+                <span class="subcategory-label good"
+                  ><i class="fa-solid fa-star"></i> Spezial</span
+                >
+                <div class="role-grid">
+                  <label class="role-chip good">
+                    <input
+                      type="checkbox"
+                      name="rollen"
+                      value="Reine Seele"
+                      data-exp="charaktere"
+                    />
+                    <span><i class="fa-solid fa-dove"></i> Reine Seele</span>
+                  </label>
+                  <label class="role-chip good">
+                    <input
+                      type="checkbox"
+                      name="rollen"
+                      value="Fuchs"
+                      data-exp="charaktere"
+                    />
+                    <span><i class="fa-solid fa-paw"></i> Fuchs</span>
+                  </label>
+                  <label class="role-chip good">
+                    <input
+                      type="checkbox"
+                      name="rollen"
+                      value="Ergebene Magd"
+                      data-exp="charaktere"
+                    />
+                    <span
+                      ><i class="fa-solid fa-hand-holding-heart"></i> Ergebene
+                      Magd</span
+                    >
+                  </label>
+                  <label class="role-chip good">
+                    <input
+                      type="checkbox"
+                      name="rollen"
+                      value="Baerenbaendiger"
+                      data-exp="charaktere"
+                    />
+                    <span><i class="fa-solid fa-hippo"></i> Bärenführer</span>
+                  </label>
+                  <label class="role-chip good">
+                    <input
+                      type="checkbox"
+                      name="rollen"
+                      value="Ritter"
+                      data-exp="charaktere"
+                    />
+                    <span
+                      ><i class="fa-solid fa-shield-halved"></i> Rostiger
+                      Ritter</span
+                    >
+                  </label>
+                  <label class="role-chip good">
+                    <input
+                      type="checkbox"
+                      name="rollen"
+                      value="Gaukler"
+                      data-exp="charaktere"
+                    />
+                    <span
+                      ><i class="fa-solid fa-masks-theater"></i> Gaukler</span
+                    >
+                  </label>
+                  <label class="role-chip good">
+                    <input
+                      type="checkbox"
+                      name="rollen"
+                      value="Richter"
+                      data-exp="charaktere"
+                    />
+                    <span><i class="fa-solid fa-gavel"></i> Richter</span>
+                  </label>
                 </div>
+              </div>
+
+              <!-- Solo/Neutral -->
+              <div class="role-subcategory">
+                <span class="subcategory-label neutral"
+                  ><i class="fa-solid fa-user-secret"></i> Solo</span
+                >
+                <div class="role-grid">
+                  <label class="role-chip neutral">
+                    <input
+                      type="checkbox"
+                      name="rollen"
+                      value="Engel"
+                      data-exp="charaktere"
+                    />
+                    <span><i class="fa-solid fa-feather"></i> Engel</span>
+                  </label>
+                  <label class="role-chip neutral">
+                    <input
+                      type="checkbox"
+                      name="rollen"
+                      value="Verbitterter Greis"
+                      data-exp="charaktere"
+                    />
+                    <span
+                      ><i class="fa-solid fa-person-cane"></i> Verb. Greis</span
+                    >
+                  </label>
+                </div>
+              </div>
             </div>
+          </div>
+
+          <!-- ===== COMMUNITY ROLLEN ===== -->
+          <div class="expansion-card community" data-expansion="community">
+            <div
+              class="expansion-header"
+              onclick="toggleExpansion('community')"
+            >
+              <div class="expansion-title">
+                <label class="expansion-check">
+                  <input
+                    type="checkbox"
+                    name="expansion_community"
+                    onchange="toggleExpansionRoles('community', this.checked)"
+                  />
+                  <span class="checkmark"></span>
+                </label>
+                <i class="fa-solid fa-puzzle-piece"></i>
+                <span>Community-Rollen</span>
+                <span class="expansion-badge community">Inoffiziell</span>
+              </div>
+              <i class="fa-solid fa-chevron-down expansion-toggle"></i>
+            </div>
+            <div class="expansion-content">
+              <p class="expansion-desc">
+                Beliebte Fan-Kreationen und Varianten
+              </p>
+
+              <!-- Böse -->
+              <div class="role-subcategory">
+                <span class="subcategory-label evil"
+                  ><i class="fa-solid fa-skull"></i> Team Böse</span
+                >
+                <div class="role-grid">
+                  <label class="role-chip evil">
+                    <input
+                      type="checkbox"
+                      name="rollen"
+                      value="Wolfsjunge"
+                      data-exp="community"
+                    />
+                    <span><i class="fa-solid fa-baby"></i> Wolfsjunge</span>
+                  </label>
+                  <label class="role-chip evil">
+                    <input
+                      type="checkbox"
+                      name="rollen"
+                      value="Wolf im Schafspelz"
+                      data-exp="community"
+                    />
+                    <span
+                      ><i class="fa-solid fa-sheep"></i> Wolf im
+                      Schafspelz</span
+                    >
+                  </label>
+                  <label class="role-chip evil">
+                    <input
+                      type="checkbox"
+                      name="rollen"
+                      value="Werwolfseherin"
+                      data-exp="community"
+                    />
+                    <span
+                      ><i class="fa-solid fa-eye-evil"></i>
+                      Werwolf-Seherin</span
+                    >
+                  </label>
+                </div>
+              </div>
+
+              <!-- Gut -->
+              <div class="role-subcategory">
+                <span class="subcategory-label good"
+                  ><i class="fa-solid fa-shield"></i> Team Dorf</span
+                >
+                <div class="role-grid">
+                  <label class="role-chip good">
+                    <input
+                      type="checkbox"
+                      name="rollen"
+                      value="Leibwaechter"
+                      data-exp="community"
+                    />
+                    <span><i class="fa-solid fa-shield"></i> Leibwächter</span>
+                  </label>
+                  <label class="role-chip good">
+                    <input
+                      type="checkbox"
+                      name="rollen"
+                      value="Medium"
+                      data-exp="community"
+                    />
+                    <span><i class="fa-solid fa-ghost"></i> Medium</span>
+                  </label>
+                  <label class="role-chip good">
+                    <input
+                      type="checkbox"
+                      name="rollen"
+                      value="Aurenseherin"
+                      data-exp="community"
+                    />
+                    <span><i class="fa-solid fa-sun"></i> Aura-Seherin</span>
+                  </label>
+                  <label class="role-chip good">
+                    <input
+                      type="checkbox"
+                      name="rollen"
+                      value="Freimaurer"
+                      data-exp="community"
+                    />
+                    <span
+                      ><i class="fa-solid fa-handshake"></i> Freimaurer</span
+                    >
+                  </label>
+                  <label class="role-chip good">
+                    <input
+                      type="checkbox"
+                      name="rollen"
+                      value="Prinz"
+                      data-exp="community"
+                    />
+                    <span><i class="fa-solid fa-crown"></i> Prinz</span>
+                  </label>
+                  <label class="role-chip good">
+                    <input
+                      type="checkbox"
+                      name="rollen"
+                      value="Buergermeister"
+                      data-exp="community"
+                    />
+                    <span
+                      ><i class="fa-solid fa-landmark"></i> Bürgermeister</span
+                    >
+                  </label>
+                </div>
+              </div>
+
+              <!-- Solo/Chaos -->
+              <div class="role-subcategory">
+                <span class="subcategory-label neutral"
+                  ><i class="fa-solid fa-dice"></i> Chaos & Solo</span
+                >
+                <div class="role-grid">
+                  <label class="role-chip neutral">
+                    <input
+                      type="checkbox"
+                      name="rollen"
+                      value="Vampir"
+                      data-exp="community"
+                    />
+                    <span><i class="fa-solid fa-teeth"></i> Vampir</span>
+                  </label>
+                  <label class="role-chip neutral">
+                    <input
+                      type="checkbox"
+                      name="rollen"
+                      value="Zombie"
+                      data-exp="community"
+                    />
+                    <span><i class="fa-solid fa-biohazard"></i> Zombie</span>
+                  </label>
+                  <label class="role-chip neutral">
+                    <input
+                      type="checkbox"
+                      name="rollen"
+                      value="Pyromane"
+                      data-exp="community"
+                    />
+                    <span><i class="fa-solid fa-fire"></i> Pyromane</span>
+                  </label>
+                  <label class="role-chip neutral">
+                    <input
+                      type="checkbox"
+                      name="rollen"
+                      value="Doppelgaenger"
+                      data-exp="community"
+                    />
+                    <span><i class="fa-solid fa-clone"></i> Doppelgänger</span>
+                  </label>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Aktive Rollen Übersicht -->
+          <div class="roles-summary" id="roles-summary">
+            <div class="summary-header">
+              <span><i class="fa-solid fa-list-check"></i> Aktive Rollen:</span>
+              <span class="role-count" id="role-count">2</span>
+            </div>
+            <div class="roles-preview" id="roles-preview">
+              <!-- Dynamisch gefüllt -->
+            </div>
+          </div>
         </div>
-    </section>
-    
-    <!-- Spielmodi Erklärung -->
-    <section class="fade-in delay-2" style="max-width: 900px; margin: 2rem auto 0;">
-        <div class="grid grid-2">
-            <div class="card" style="border-color: var(--accent-blue);">
-                <h4 style="color: var(--accent-blue);">
-                    <i class="fa-solid fa-wifi"></i> Online-Modus
-                </h4>
-                <p class="text-muted mb-2">Jeder Spieler auf eigenem Gerät - das Spiel erzählt automatisch.</p>
-                <ul class="text-muted" style="font-size: 0.9rem; padding-left: 1.5rem;">
-                    <li>Kein Erzähler nötig</li>
-                    <li>Das Spiel führt durch alle Phasen</li>
-                    <li>Automatische Nachrichten und Anweisungen</li>
-                    <li>Perfekt für Remote-Spielrunden</li>
-                </ul>
-            </div>
-            <div class="card" style="border-color: var(--accent-gold);">
-                <h4 style="color: var(--accent-gold);">
-                    <i class="fa-solid fa-users"></i> Gruppen-Modus
-                </h4>
-                <p class="text-muted mb-2">Alle zusammen vor Ort - der Erzähler erhält Anleitungen.</p>
-                <ul class="text-muted" style="font-size: 0.9rem; padding-left: 1.5rem;">
-                    <li>Mit menschlichem Erzähler</li>
-                    <li>Erzähler erhält vorgefertigte Texte</li>
-                    <li>Klassisches Spielerlebnis</li>
-                    <li>Perfekt für Partys und Spieleabende</li>
-                </ul>
-            </div>
+
+        <!-- Erweiterte Einstellungen Toggle -->
+        <div class="form-group" style="margin-top: 1rem">
+          <button
+            type="button"
+            class="btn btn-ghost btn-sm"
+            onclick="toggleErweitert()"
+            style="width: 100%; opacity: 0.7"
+          >
+            <i class="fa-solid fa-cog" id="erweitert-icon"></i> Weitere Optionen
+            <i class="fa-solid fa-chevron-down" id="erweitert-chevron"></i>
+          </button>
         </div>
-    </section>
-    
-    <!-- Rollen Übersicht (Auswahl) -->
-    <section class="fade-in delay-3" style="max-width: 900px; margin: 3rem auto 0;">
-        <h3 class="text-center mb-3" style="color: var(--accent-gold);">Die wichtigsten Rollen</h3>
-        
-        <div class="grid grid-3">
-            <div class="card" style="border-color: var(--accent-red);">
-                <h4 style="color: var(--accent-red);">
-                    <i class="fa-solid fa-paw"></i> Werwolf
-                </h4>
-                <p class="text-muted">Töte jede Nacht einen Dorfbewohner und bleibe unentdeckt.</p>
-            </div>
-            <div class="card">
-                <h4 style="color: #7c3aed;">
-                    <i class="fa-solid fa-eye"></i> Seherin
-                </h4>
-                <p class="text-muted">Erfahre jede Nacht die wahre Identität eines Spielers.</p>
-            </div>
-            <div class="card">
-                <h4 style="color: var(--accent-green);">
-                    <i class="fa-solid fa-hat-wizard"></i> Hexe
-                </h4>
-                <p class="text-muted">Heile oder vergifte - aber jeder Trank wirkt nur einmal.</p>
-            </div>
-            <div class="card">
-                <h4 style="color: #b8860b;">
-                    <i class="fa-solid fa-crosshairs"></i> Jäger
-                </h4>
-                <p class="text-muted">Wenn du stirbst, nimmst du jemanden mit in den Tod.</p>
-            </div>
-            <div class="card">
-                <h4 style="color: #ff69b4;">
-                    <i class="fa-solid fa-heart"></i> Amor
-                </h4>
-                <p class="text-muted">Verliebe zwei Spieler - sie gewinnen nur gemeinsam.</p>
-            </div>
-            <div class="card">
-                <h4 style="color: #10b981;">
-                    <i class="fa-solid fa-heart-pulse"></i> Heiler
-                </h4>
-                <p class="text-muted">Schütze jede Nacht einen Spieler vor den Wölfen.</p>
-            </div>
+
+        <!-- Erweiterte Einstellungen (versteckt) -->
+        <div id="erweiterte-einstellungen" style="display: none">
+          <!-- Regelset Auswahl -->
+          <div class="form-group">
+            <label class="form-label">Regelset</label>
+            <select name="regelset" class="form-input">
+              <option value="standard">Standard - Klassische Regeln</option>
+              <option value="schnell">Schnellspiel - Kürzere Zeiten</option>
+              <option value="chaos">Chaos - Mehr Überraschungen</option>
+              <option value="profi">
+                Profi - Weniger Hinweise, mehr Strategie
+              </option>
+              <option value="party">Party - Lockere Regeln</option>
+            </select>
+          </div>
+
+          <!-- Hinweise aktivieren (nur Online) -->
+          <div class="form-group" id="hinweise-option">
+            <label class="form-checkbox">
+              <input type="checkbox" name="hinweise_aktiv" checked />
+              <span>Visuelle Hinweise aktivieren</span>
+            </label>
+          </div>
+
+          <!-- Audio-Erzähler (nur Online) -->
+          <div class="form-group" id="audio-option">
+            <label class="form-checkbox">
+              <input type="checkbox" name="audio_erzaehler" checked />
+              <span>Audio-Erzähler aktivieren</span>
+            </label>
+          </div>
         </div>
-        
-        <div class="text-center mt-3">
-            <a href="{{ url_for('rollen_uebersicht') }}" class="btn btn-ghost">
-                Alle {{ alle_rollen|length }} Rollen ansehen <i class="fa-solid fa-arrow-right"></i>
-            </a>
+
+        <button type="submit" class="btn btn-primary btn-block btn-lg">
+          Spiel erstellen
+        </button>
+      </form>
+    </div>
+
+    <!-- Bestehendem Spiel beitreten -->
+    <div class="card">
+      <div class="card-header">
+        <h2 style="color: var(--accent-blue); font-size: 1.5rem">
+          <i class="fa-solid fa-door-open"></i> Spiel beitreten
+        </h2>
+      </div>
+
+      <form action="{{ url_for('raum_beitreten') }}" method="POST">
+        <div class="form-group">
+          <label class="form-label">Dein Name</label>
+          <input
+            type="text"
+            name="spieler_name"
+            class="form-input"
+            placeholder="Dein Name"
+            maxlength="30"
+            required
+          />
         </div>
-    </section>
+
+        <div class="form-group">
+          <label class="form-label">Raumcode</label>
+          <input
+            type="text"
+            name="code"
+            class="form-input"
+            placeholder="ABC123"
+            maxlength="6"
+            style="
+              text-transform: uppercase;
+              letter-spacing: 0.2em;
+              font-size: 1.5rem;
+              text-align: center;
+            "
+            required
+          />
+        </div>
+
+        <div style="flex: 1"></div>
+
+        <button
+          type="submit"
+          class="btn btn-secondary btn-block btn-lg"
+          style="margin-top: 2rem"
+        >
+          Beitreten
+        </button>
+      </form>
+    </div>
+  </section>
+
+  <!-- Spielanleitung -->
+  <section
+    class="fade-in delay-2"
+    style="max-width: 900px; margin: 4rem auto 0"
+  >
+    <div class="card">
+      <h3 style="color: var(--accent-gold); margin-bottom: 1.5rem">
+        Wie funktioniert es?
+      </h3>
+
+      <div class="grid grid-3" style="text-align: center">
+        <div>
+          <div
+            style="
+              font-size: 2.5rem;
+              margin-bottom: 0.5rem;
+              color: var(--accent-gold);
+            "
+          >
+            <i class="fa-solid fa-plus-circle"></i>
+          </div>
+          <h4 class="mb-1">Raum erstellen</h4>
+          <p class="text-muted">
+            Erstelle einen Raum und teile den Code mit deinen Freunden.
+          </p>
+        </div>
+        <div>
+          <div
+            style="
+              font-size: 2.5rem;
+              margin-bottom: 0.5rem;
+              color: var(--accent-blue);
+            "
+          >
+            <i class="fa-solid fa-user-secret"></i>
+          </div>
+          <h4 class="mb-1">Rollen erhalten</h4>
+          <p class="text-muted">
+            Jeder Spieler bekommt eine geheime Rolle zugewiesen.
+          </p>
+        </div>
+        <div>
+          <div
+            style="
+              font-size: 2.5rem;
+              margin-bottom: 0.5rem;
+              color: var(--accent-red);
+            "
+          >
+            <i class="fa-solid fa-gamepad"></i>
+          </div>
+          <h4 class="mb-1">Spielen!</h4>
+          <p class="text-muted">
+            Entlarve die Werwölfe oder eliminiere das Dorf.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Spielmodi Erklärung -->
+  <section
+    class="fade-in delay-2"
+    style="max-width: 900px; margin: 2rem auto 0"
+  >
+    <div class="grid grid-2">
+      <div class="card" style="border-color: var(--accent-blue)">
+        <h4 style="color: var(--accent-blue)">
+          <i class="fa-solid fa-wifi"></i> Online-Modus
+        </h4>
+        <p class="text-muted mb-2">
+          Jeder Spieler auf eigenem Gerät - das Spiel erzählt automatisch.
+        </p>
+        <ul class="text-muted" style="font-size: 0.9rem; padding-left: 1.5rem">
+          <li>Kein Erzähler nötig</li>
+          <li>Das Spiel führt durch alle Phasen</li>
+          <li>Automatische Nachrichten und Anweisungen</li>
+          <li>Perfekt für Remote-Spielrunden</li>
+        </ul>
+      </div>
+      <div class="card" style="border-color: var(--accent-gold)">
+        <h4 style="color: var(--accent-gold)">
+          <i class="fa-solid fa-users"></i> Gruppen-Modus
+        </h4>
+        <p class="text-muted mb-2">
+          Alle zusammen vor Ort - der Erzähler erhält Anleitungen.
+        </p>
+        <ul class="text-muted" style="font-size: 0.9rem; padding-left: 1.5rem">
+          <li>Mit menschlichem Erzähler</li>
+          <li>Erzähler erhält vorgefertigte Texte</li>
+          <li>Klassisches Spielerlebnis</li>
+          <li>Perfekt für Partys und Spieleabende</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- Rollen Übersicht (Auswahl) -->
+  <section
+    class="fade-in delay-3"
+    style="max-width: 900px; margin: 3rem auto 0"
+  >
+    <h3 class="text-center mb-3" style="color: var(--accent-gold)">
+      Die wichtigsten Rollen
+    </h3>
+
+    <div class="grid grid-3">
+      <div class="card" style="border-color: var(--accent-red)">
+        <h4 style="color: var(--accent-red)">
+          <i class="fa-solid fa-paw"></i> Werwolf
+        </h4>
+        <p class="text-muted">
+          Töte jede Nacht einen Dorfbewohner und bleibe unentdeckt.
+        </p>
+      </div>
+      <div class="card">
+        <h4 style="color: #7c3aed"><i class="fa-solid fa-eye"></i> Seherin</h4>
+        <p class="text-muted">
+          Erfahre jede Nacht die wahre Identität eines Spielers.
+        </p>
+      </div>
+      <div class="card">
+        <h4 style="color: var(--accent-green)">
+          <i class="fa-solid fa-hat-wizard"></i> Hexe
+        </h4>
+        <p class="text-muted">
+          Heile oder vergifte - aber jeder Trank wirkt nur einmal.
+        </p>
+      </div>
+      <div class="card">
+        <h4 style="color: #b8860b">
+          <i class="fa-solid fa-crosshairs"></i> Jäger
+        </h4>
+        <p class="text-muted">
+          Wenn du stirbst, nimmst du jemanden mit in den Tod.
+        </p>
+      </div>
+      <div class="card">
+        <h4 style="color: #ff69b4"><i class="fa-solid fa-heart"></i> Amor</h4>
+        <p class="text-muted">
+          Verliebe zwei Spieler - sie gewinnen nur gemeinsam.
+        </p>
+      </div>
+      <div class="card">
+        <h4 style="color: #10b981">
+          <i class="fa-solid fa-heart-pulse"></i> Heiler
+        </h4>
+        <p class="text-muted">
+          Schütze jede Nacht einen Spieler vor den Wölfen.
+        </p>
+      </div>
+    </div>
+
+    <div class="text-center mt-3">
+      <a href="{{ url_for('rollen_uebersicht') }}" class="btn btn-ghost">
+        Alle {{ alle_rollen|length }} Rollen ansehen
+        <i class="fa-solid fa-arrow-right"></i>
+      </a>
+    </div>
+  </section>
 </div>
 
 <style>
-/* ============================================ */
-/* ROLLEN-WIZARD STYLES */
-/* ============================================ */
+  /* ============================================ */
+  /* ROLLEN-WIZARD STYLES */
+  /* ============================================ */
 
-.rollen-wizard {
+  .rollen-wizard {
     margin-top: 1.5rem;
     padding: 1rem;
-    background: rgba(0,0,0,0.2);
+    background: rgba(0, 0, 0, 0.2);
     border-radius: 12px;
-    border: 1px solid rgba(255,255,255,0.1);
-}
+    border: 1px solid rgba(255, 255, 255, 0.1);
+  }
 
-.wizard-header {
+  .wizard-header {
     text-align: center;
     margin-bottom: 1rem;
     padding-bottom: 0.75rem;
-    border-bottom: 1px solid rgba(255,255,255,0.1);
-}
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  }
 
-.wizard-header h3 {
+  .wizard-header h3 {
     color: var(--accent-gold);
     font-size: 1.25rem;
     margin: 0 0 0.25rem 0;
-}
+  }
 
-.wizard-subtitle {
+  .wizard-subtitle {
     color: var(--text-muted);
     font-size: 0.85rem;
     margin: 0;
-}
+  }
 
-/* Expansion Cards */
-.expansion-card {
-    background: rgba(255,255,255,0.03);
-    border: 1px solid rgba(255,255,255,0.1);
+  /* Expansion Cards */
+  .expansion-card {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.1);
     border-radius: 8px;
     margin-bottom: 0.5rem;
     overflow: hidden;
     transition: all 0.2s;
-}
+  }
 
-.expansion-card:hover {
-    border-color: rgba(255,255,255,0.2);
-}
+  .expansion-card:hover {
+    border-color: rgba(255, 255, 255, 0.2);
+  }
 
-.expansion-card.active {
+  .expansion-card.active {
     border-color: var(--accent-gold);
-}
+  }
 
-.expansion-header {
+  .expansion-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
     padding: 0.75rem 1rem;
     cursor: pointer;
     user-select: none;
-}
+  }
 
-.expansion-header:hover {
-    background: rgba(255,255,255,0.05);
-}
+  .expansion-header:hover {
+    background: rgba(255, 255, 255, 0.05);
+  }
 
-.expansion-title {
+  .expansion-title {
     display: flex;
     align-items: center;
     gap: 0.5rem;
     font-weight: 500;
     color: var(--text-primary);
-}
+  }
 
-.expansion-title i {
+  .expansion-title i {
     font-size: 1rem;
     width: 20px;
     text-align: center;
-}
+  }
 
-.expansion-check {
+  .expansion-check {
     display: flex;
     align-items: center;
     cursor: pointer;
-}
+  }
 
-.expansion-check input {
+  .expansion-check input {
     display: none;
-}
+  }
 
-.expansion-check .checkmark {
+  .expansion-check .checkmark {
     width: 18px;
     height: 18px;
-    border: 2px solid rgba(255,255,255,0.3);
+    border: 2px solid rgba(255, 255, 255, 0.3);
     border-radius: 4px;
     display: flex;
     align-items: center;
     justify-content: center;
     transition: all 0.15s;
-}
+  }
 
-.expansion-check input:checked + .checkmark {
+  .expansion-check input:checked + .checkmark {
     background: var(--accent-gold);
     border-color: var(--accent-gold);
-}
+  }
 
-.expansion-check input:checked + .checkmark::after {
-    content: '';
+  .expansion-check input:checked + .checkmark::after {
+    content: "";
     display: block;
     width: 5px;
     height: 10px;
@@ -794,84 +1200,84 @@
     border-width: 0 2px 2px 0;
     transform: rotate(45deg);
     margin: 2px auto;
-}
+  }
 
-.expansion-check input:disabled + .checkmark {
+  .expansion-check input:disabled + .checkmark {
     background: var(--accent-green);
     border-color: var(--accent-green);
     opacity: 0.8;
-}
+  }
 
-.expansion-badge {
+  .expansion-badge {
     font-size: 0.65rem;
     padding: 0.15rem 0.4rem;
     border-radius: 4px;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.5px;
-}
+  }
 
-.expansion-badge.required {
+  .expansion-badge.required {
     background: rgba(16, 185, 129, 0.2);
     color: #34d399;
-}
+  }
 
-.expansion-badge.exp1 {
+  .expansion-badge.exp1 {
     background: rgba(99, 102, 241, 0.2);
     color: #a5b4fc;
-}
+  }
 
-.expansion-badge.exp2 {
+  .expansion-badge.exp2 {
     background: rgba(236, 72, 153, 0.2);
     color: #f9a8d4;
-}
+  }
 
-.expansion-badge.exp3 {
+  .expansion-badge.exp3 {
     background: rgba(251, 146, 60, 0.2);
     color: #fdba74;
-}
+  }
 
-.expansion-badge.community {
+  .expansion-badge.community {
     background: rgba(139, 92, 246, 0.2);
     color: #c4b5fd;
-}
+  }
 
-.expansion-toggle {
+  .expansion-toggle {
     color: var(--text-muted);
     transition: transform 0.2s;
-}
+  }
 
-.expansion-card.open .expansion-toggle {
+  .expansion-card.open .expansion-toggle {
     transform: rotate(180deg);
-}
+  }
 
-.expansion-content {
+  .expansion-content {
     display: none;
     padding: 0.75rem 1rem 1rem;
-    border-top: 1px solid rgba(255,255,255,0.05);
-    background: rgba(0,0,0,0.1);
-}
+    border-top: 1px solid rgba(255, 255, 255, 0.05);
+    background: rgba(0, 0, 0, 0.1);
+  }
 
-.expansion-card.open .expansion-content {
+  .expansion-card.open .expansion-content {
     display: block;
-}
+  }
 
-.expansion-desc {
+  .expansion-desc {
     color: var(--text-muted);
     font-size: 0.8rem;
     margin: 0 0 0.75rem 0;
-}
+  }
 
-/* Role Subcategories */
-.role-subcategory {
+  /* Role Subcategories */
+  .role-subcategory {
     margin-bottom: 0.75rem;
-}
+  }
 
-.role-subcategory:last-child {
+  .role-subcategory:last-child {
     margin-bottom: 0;
-}
+  }
 
-.subcategory-label {
+  .subcategory-label {
     display: inline-flex;
     align-items: center;
     gap: 0.375rem;
@@ -880,90 +1286,90 @@
     padding: 0.2rem 0.5rem;
     border-radius: 4px;
     margin-bottom: 0.375rem;
-}
+  }
 
-.subcategory-label.evil {
+  .subcategory-label.evil {
     background: rgba(220, 38, 38, 0.15);
     color: #fca5a5;
-}
+  }
 
-.subcategory-label.good {
+  .subcategory-label.good {
     background: rgba(16, 185, 129, 0.15);
     color: #6ee7b7;
-}
+  }
 
-.subcategory-label.neutral {
+  .subcategory-label.neutral {
     background: rgba(212, 175, 55, 0.15);
     color: #fde68a;
-}
+  }
 
-/* Role Grid & Chips */
-.role-grid {
+  /* Role Grid & Chips */
+  .role-grid {
     display: flex;
     flex-wrap: wrap;
     gap: 0.375rem;
-}
+  }
 
-.role-chip {
+  .role-chip {
     display: inline-flex;
     align-items: center;
     gap: 0.375rem;
     padding: 0.375rem 0.625rem;
-    background: rgba(255,255,255,0.05);
-    border: 1px solid rgba(255,255,255,0.15);
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.15);
     border-radius: 6px;
     cursor: pointer;
     transition: all 0.15s;
     font-size: 0.75rem;
     color: var(--text-muted);
-}
+  }
 
-.role-chip:hover {
-    background: rgba(255,255,255,0.1);
+  .role-chip:hover {
+    background: rgba(255, 255, 255, 0.1);
     color: var(--text-primary);
-}
+  }
 
-.role-chip input[type="checkbox"] {
+  .role-chip input[type="checkbox"] {
     display: none;
-}
+  }
 
-.role-chip:has(input:disabled) {
+  .role-chip:has(input:disabled) {
     opacity: 0.7;
     cursor: not-allowed;
-}
+  }
 
-.role-chip.evil:has(input:checked) {
+  .role-chip.evil:has(input:checked) {
     background: rgba(220, 38, 38, 0.25);
     border-color: rgba(220, 38, 38, 0.5);
     color: #fca5a5;
-}
+  }
 
-.role-chip.good:has(input:checked) {
+  .role-chip.good:has(input:checked) {
     background: rgba(16, 185, 129, 0.25);
     border-color: rgba(16, 185, 129, 0.5);
     color: #6ee7b7;
-}
+  }
 
-.role-chip.neutral:has(input:checked) {
+  .role-chip.neutral:has(input:checked) {
     background: rgba(212, 175, 55, 0.25);
     border-color: rgba(212, 175, 55, 0.5);
     color: #fde68a;
-}
+  }
 
-.role-chip span i {
+  .role-chip span i {
     font-size: 0.875rem;
-}
+  }
 
-/* Roles Summary */
-.roles-summary {
+  /* Roles Summary */
+  .roles-summary {
     margin-top: 1rem;
     padding: 0.75rem;
     background: rgba(212, 175, 55, 0.1);
     border: 1px solid rgba(212, 175, 55, 0.3);
     border-radius: 8px;
-}
+  }
 
-.summary-header {
+  .summary-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -971,24 +1377,24 @@
     font-size: 0.85rem;
     color: var(--accent-gold);
     font-weight: 500;
-}
+  }
 
-.role-count {
+  .role-count {
     background: var(--accent-gold);
     color: #000;
     padding: 0.125rem 0.5rem;
     border-radius: 999px;
     font-weight: 600;
     font-size: 0.8rem;
-}
+  }
 
-.roles-preview {
+  .roles-preview {
     display: flex;
     flex-wrap: wrap;
     gap: 0.375rem;
-}
+  }
 
-.role-tag {
+  .role-tag {
     display: inline-flex;
     align-items: center;
     gap: 0.25rem;
@@ -996,222 +1402,242 @@
     border-radius: 999px;
     font-size: 0.7rem;
     font-weight: 500;
-}
+  }
 
-.role-tag.evil { background: rgba(220, 38, 38, 0.3); color: #fca5a5; }
-.role-tag.good { background: rgba(16, 185, 129, 0.3); color: #6ee7b7; }
-.role-tag.neutral { background: rgba(212, 175, 55, 0.3); color: #fde68a; }
+  .role-tag.evil {
+    background: rgba(220, 38, 38, 0.3);
+    color: #fca5a5;
+  }
+  .role-tag.good {
+    background: rgba(16, 185, 129, 0.3);
+    color: #6ee7b7;
+  }
+  .role-tag.neutral {
+    background: rgba(212, 175, 55, 0.3);
+    color: #fde68a;
+  }
 </style>
 
 <script>
-// ============================================
-// ROLLEN-WIZARD JAVASCRIPT
-// ============================================
+  // ============================================
+  // ROLLEN-WIZARD JAVASCRIPT
+  // ============================================
 
-// Role metadata for display
-const ROLE_META = {
-    'Werwolf': { icon: 'fa-paw', type: 'evil' },
-    'Dorfbewohner': { icon: 'fa-user', type: 'good' },
-    'Seherin': { icon: 'fa-eye', type: 'good' },
-    'Hexe': { icon: 'fa-hat-wizard', type: 'good' },
-    'Jaeger': { icon: 'fa-crosshairs', type: 'good' },
-    'Amor': { icon: 'fa-heart', type: 'good' },
-    'Dieb': { icon: 'fa-mask', type: 'good' },
-    'Maedchen': { icon: 'fa-child', type: 'good' },
-    'Heiler': { icon: 'fa-heart-pulse', type: 'good' },
-    'Alter Mann': { icon: 'fa-person-cane', type: 'good' },
-    'Suendenbock': { icon: 'fa-sheep', type: 'good' },
-    'Dorfdepp': { icon: 'fa-face-grin-tongue', type: 'good' },
-    'Floetenspieler': { icon: 'fa-music', type: 'neutral' },
-    'Brandstifter': { icon: 'fa-fire-flame-curved', type: 'good' },
-    'Rabe': { icon: 'fa-crow', type: 'good' },
-    'Grosser boeser Wolf': { icon: 'fa-paw', type: 'evil' },
-    'Urwolf': { icon: 'fa-paw', type: 'evil' },
-    'Weisser Wolf': { icon: 'fa-paw', type: 'neutral' },
-    'Wolfshund': { icon: 'fa-dog', type: 'good' },
-    'Wildes Kind': { icon: 'fa-child-reaching', type: 'good' },
-    'Zwei Schwestern': { icon: 'fa-user-group', type: 'good' },
-    'Drei Brueder': { icon: 'fa-users', type: 'good' },
-    'Reine Seele': { icon: 'fa-dove', type: 'good' },
-    'Fuchs': { icon: 'fa-paw', type: 'good' },
-    'Ergebene Magd': { icon: 'fa-hand-holding-heart', type: 'good' },
-    'Baerenbaendiger': { icon: 'fa-hippo', type: 'good' },
-    'Ritter': { icon: 'fa-shield-halved', type: 'good' },
-    'Gaukler': { icon: 'fa-masks-theater', type: 'good' },
-    'Richter': { icon: 'fa-gavel', type: 'good' },
-    'Engel': { icon: 'fa-feather', type: 'neutral' },
-    'Verbitterter Greis': { icon: 'fa-person-cane', type: 'neutral' },
-    'Wolfsjunge': { icon: 'fa-baby', type: 'evil' },
-    'Wolf im Schafspelz': { icon: 'fa-sheep', type: 'evil' },
-    'Werwolfseherin': { icon: 'fa-eye', type: 'evil' },
-    'Leibwaechter': { icon: 'fa-shield', type: 'good' },
-    'Medium': { icon: 'fa-ghost', type: 'good' },
-    'Aurenseherin': { icon: 'fa-sun', type: 'good' },
-    'Freimaurer': { icon: 'fa-handshake', type: 'good' },
-    'Prinz': { icon: 'fa-crown', type: 'good' },
-    'Buergermeister': { icon: 'fa-landmark', type: 'good' },
-    'Vampir': { icon: 'fa-teeth', type: 'neutral' },
-    'Zombie': { icon: 'fa-biohazard', type: 'neutral' },
-    'Pyromane': { icon: 'fa-fire', type: 'neutral' },
-    'Doppelgaenger': { icon: 'fa-clone', type: 'neutral' }
-};
+  // Role metadata for display
+  const ROLE_META = {
+    Werwolf: { icon: "fa-paw", type: "evil" },
+    Dorfbewohner: { icon: "fa-user", type: "good" },
+    Seherin: { icon: "fa-eye", type: "good" },
+    Hexe: { icon: "fa-hat-wizard", type: "good" },
+    Jaeger: { icon: "fa-crosshairs", type: "good" },
+    Amor: { icon: "fa-heart", type: "good" },
+    Dieb: { icon: "fa-mask", type: "good" },
+    Maedchen: { icon: "fa-child", type: "good" },
+    Heiler: { icon: "fa-heart-pulse", type: "good" },
+    "Alter Mann": { icon: "fa-person-cane", type: "good" },
+    Suendenbock: { icon: "fa-sheep", type: "good" },
+    Dorfdepp: { icon: "fa-face-grin-tongue", type: "good" },
+    Floetenspieler: { icon: "fa-music", type: "neutral" },
+    Brandstifter: { icon: "fa-fire-flame-curved", type: "good" },
+    Rabe: { icon: "fa-crow", type: "good" },
+    "Grosser boeser Wolf": { icon: "fa-paw", type: "evil" },
+    Urwolf: { icon: "fa-paw", type: "evil" },
+    "Weisser Wolf": { icon: "fa-paw", type: "neutral" },
+    Wolfshund: { icon: "fa-dog", type: "good" },
+    "Wildes Kind": { icon: "fa-child-reaching", type: "good" },
+    "Zwei Schwestern": { icon: "fa-user-group", type: "good" },
+    "Drei Brueder": { icon: "fa-users", type: "good" },
+    "Reine Seele": { icon: "fa-dove", type: "good" },
+    Fuchs: { icon: "fa-paw", type: "good" },
+    "Ergebene Magd": { icon: "fa-hand-holding-heart", type: "good" },
+    Baerenbaendiger: { icon: "fa-hippo", type: "good" },
+    Ritter: { icon: "fa-shield-halved", type: "good" },
+    Gaukler: { icon: "fa-masks-theater", type: "good" },
+    Richter: { icon: "fa-gavel", type: "good" },
+    Engel: { icon: "fa-feather", type: "neutral" },
+    "Verbitterter Greis": { icon: "fa-person-cane", type: "neutral" },
+    Wolfsjunge: { icon: "fa-baby", type: "evil" },
+    "Wolf im Schafspelz": { icon: "fa-sheep", type: "evil" },
+    Werwolfseherin: { icon: "fa-eye", type: "evil" },
+    Leibwaechter: { icon: "fa-shield", type: "good" },
+    Medium: { icon: "fa-ghost", type: "good" },
+    Aurenseherin: { icon: "fa-sun", type: "good" },
+    Freimaurer: { icon: "fa-handshake", type: "good" },
+    Prinz: { icon: "fa-crown", type: "good" },
+    Buergermeister: { icon: "fa-landmark", type: "good" },
+    Vampir: { icon: "fa-teeth", type: "neutral" },
+    Zombie: { icon: "fa-biohazard", type: "neutral" },
+    Pyromane: { icon: "fa-fire", type: "neutral" },
+    Doppelgaenger: { icon: "fa-clone", type: "neutral" },
+  };
 
-// Toggle expansion card open/closed
-function toggleExpansion(expansionId) {
+  // Toggle expansion card open/closed
+  function toggleExpansion(expansionId) {
     const card = document.querySelector(`[data-expansion="${expansionId}"]`);
     if (card) {
-        card.classList.toggle('open');
+      card.classList.toggle("open");
     }
-}
+  }
 
-// Enable/disable all roles in an expansion
-function toggleExpansionRoles(expansionId, enabled) {
+  // Enable/disable all roles in an expansion
+  function toggleExpansionRoles(expansionId, enabled) {
     const card = document.querySelector(`[data-expansion="${expansionId}"]`);
     if (card) {
-        // Toggle active state on card
-        card.classList.toggle('active', enabled);
-        
-        // If enabled, open the card
+      // Toggle active state on card
+      card.classList.toggle("active", enabled);
+
+      // If enabled, open the card
+      if (enabled) {
+        card.classList.add("open");
+      }
+
+      // Enable/disable all checkboxes in this expansion
+      const checkboxes = card.querySelectorAll(
+        `input[data-exp="${expansionId}"]`,
+      );
+      checkboxes.forEach((cb) => {
         if (enabled) {
-            card.classList.add('open');
+          cb.checked = true;
+        } else {
+          cb.checked = false;
         }
-        
-        // Enable/disable all checkboxes in this expansion
-        const checkboxes = card.querySelectorAll(`input[data-exp="${expansionId}"]`);
-        checkboxes.forEach(cb => {
-            if (enabled) {
-                cb.checked = true;
-            } else {
-                cb.checked = false;
-            }
-        });
-        
-        updateRolesPreview();
-    }
-}
+      });
 
-// Update the roles preview and count
-function updateRolesPreview() {
-    const preview = document.getElementById('roles-preview');
-    const countEl = document.getElementById('role-count');
+      updateRolesPreview();
+    }
+  }
+
+  // Update the roles preview and count
+  function updateRolesPreview() {
+    const preview = document.getElementById("roles-preview");
+    const countEl = document.getElementById("role-count");
     const checkedRoles = [];
-    
+
     // Get all checked roles
-    document.querySelectorAll('.rollen-wizard input[name="rollen"]:checked').forEach(cb => {
+    document
+      .querySelectorAll('.rollen-wizard input[name="rollen"]:checked')
+      .forEach((cb) => {
         checkedRoles.push(cb.value);
-    });
-    
+      });
+
     // Update count
     if (countEl) {
-        countEl.textContent = checkedRoles.length;
+      countEl.textContent = checkedRoles.length;
     }
-    
+
     // Build preview HTML
-    let html = '';
-    checkedRoles.forEach(role => {
-        const meta = ROLE_META[role] || { icon: 'fa-user', type: 'good' };
-        const displayName = role
-            .replace('Weisser', 'Weiß.')
-            .replace('Grosser boeser', 'Gr.Bös.')
-            .replace('Zwei Schwestern', '2 Schw.')
-            .replace('Drei Brueder', '3 Brüd.')
-            .replace('Alter Mann', 'Der Alte')
-            .replace('Floetenspieler', 'Flötensp.')
-            .replace('Baerenbaendiger', 'Bärenf.')
-            .replace('Ergebene Magd', 'Magd')
-            .replace('Verbitterter Greis', 'V.Greis')
-            .replace('Wolf im Schafspelz', 'W.i.Schaf')
-            .replace('Werwolfseherin', 'W-Seherin')
-            .replace('Aurenseherin', 'A-Seherin')
-            .replace('Doppelgaenger', 'Doppelg.')
-            .replace('Suendenbock', 'Sündenb.')
-            .replace('Buergermeister', 'Bürgerme.');
-        html += `<span class="role-tag ${meta.type}"><i class="fa-solid ${meta.icon}"></i> ${displayName}</span>`;
+    let html = "";
+    checkedRoles.forEach((role) => {
+      const meta = ROLE_META[role] || { icon: "fa-user", type: "good" };
+      const displayName = role
+        .replace("Weisser", "Weiß.")
+        .replace("Grosser boeser", "Gr.Bös.")
+        .replace("Zwei Schwestern", "2 Schw.")
+        .replace("Drei Brueder", "3 Brüd.")
+        .replace("Alter Mann", "Der Alte")
+        .replace("Floetenspieler", "Flötensp.")
+        .replace("Baerenbaendiger", "Bärenf.")
+        .replace("Ergebene Magd", "Magd")
+        .replace("Verbitterter Greis", "V.Greis")
+        .replace("Wolf im Schafspelz", "W.i.Schaf")
+        .replace("Werwolfseherin", "W-Seherin")
+        .replace("Aurenseherin", "A-Seherin")
+        .replace("Doppelgaenger", "Doppelg.")
+        .replace("Suendenbock", "Sündenb.")
+        .replace("Buergermeister", "Bürgerme.");
+      html += `<span class="role-tag ${meta.type}"><i class="fa-solid ${meta.icon}"></i> ${displayName}</span>`;
     });
-    
+
     if (preview) {
-        preview.innerHTML = html || '<span class="text-muted">Keine Rollen ausgewählt</span>';
+      preview.innerHTML =
+        html || '<span class="text-muted">Keine Rollen ausgewählt</span>';
     }
-}
+  }
 
-// Toggle erweiterte Einstellungen
-function toggleErweitert() {
-    const erweitert = document.getElementById('erweiterte-einstellungen');
-    const chevron = document.getElementById('erweitert-chevron');
-    
-    if (erweitert && erweitert.style.display === 'none') {
-        erweitert.style.display = 'block';
-        if (chevron) {
-            chevron.classList.remove('fa-chevron-down');
-            chevron.classList.add('fa-chevron-up');
-        }
+  // Toggle erweiterte Einstellungen
+  function toggleErweitert() {
+    const erweitert = document.getElementById("erweiterte-einstellungen");
+    const chevron = document.getElementById("erweitert-chevron");
+
+    if (erweitert && erweitert.style.display === "none") {
+      erweitert.style.display = "block";
+      if (chevron) {
+        chevron.classList.remove("fa-chevron-down");
+        chevron.classList.add("fa-chevron-up");
+      }
     } else if (erweitert) {
-        erweitert.style.display = 'none';
-        if (chevron) {
-            chevron.classList.remove('fa-chevron-up');
-            chevron.classList.add('fa-chevron-down');
-        }
+      erweitert.style.display = "none";
+      if (chevron) {
+        chevron.classList.remove("fa-chevron-up");
+        chevron.classList.add("fa-chevron-down");
+      }
     }
-}
+  }
 
-// Initialize on page load
-document.addEventListener('DOMContentLoaded', function() {
-    var modal = document.getElementById('pre-alpha-modal');
+  // Initialize on page load
+  document.addEventListener("DOMContentLoaded", function () {
+    var modal = document.getElementById("pre-alpha-modal");
     if (modal) {
-        modal.classList.add('is-open');
-        modal.addEventListener('click', function(event) {
-            if (event.target === modal) {
-                modal.classList.remove('is-open');
-            }
+      modal.classList.add("is-open");
+      modal.addEventListener("click", function (event) {
+        if (event.target === modal) {
+          modal.classList.remove("is-open");
+        }
+      });
+      modal.querySelectorAll("[data-close-modal]").forEach(function (btn) {
+        btn.addEventListener("click", function () {
+          modal.classList.remove("is-open");
         });
-        modal.querySelectorAll('[data-close-modal]').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                modal.classList.remove('is-open');
-            });
-        });
+      });
     }
 
     // Open the basis expansion by default
     const basisCard = document.querySelector('[data-expansion="basis"]');
     if (basisCard) {
-        basisCard.classList.add('open');
+      basisCard.classList.add("open");
     }
-    
+
     // Add change listeners to all role checkboxes
-    document.querySelectorAll('.rollen-wizard input[name="rollen"]').forEach(cb => {
-        cb.addEventListener('change', updateRolesPreview);
-    });
-    
+    document
+      .querySelectorAll('.rollen-wizard input[name="rollen"]')
+      .forEach((cb) => {
+        cb.addEventListener("change", updateRolesPreview);
+      });
+
     // Initial preview update
     updateRolesPreview();
-    
+
     // Modus change handler with descriptions
     const modusDescriptions = {
-        'online': 'Jeder Spieler verwendet sein eigenes Smartphone oder Laptop. Das Spiel zeigt ein 3D-Dorf mit Sitzordnung.',
-        'gruppe': 'Alle sitzen physisch zusammen, ein Erzähler leitet das Spiel mit einem großen Bildschirm.'
+      online:
+        "Jeder Spieler verwendet sein eigenes Smartphone oder Laptop. Das Spiel zeigt ein 3D-Dorf mit Sitzordnung.",
+      gruppe:
+        "Alle sitzen physisch zusammen, ein Erzähler leitet das Spiel mit einem großen Bildschirm.",
     };
-    
-    const modusSelect = document.getElementById('modus-select');
-    const modusBeschreibung = document.getElementById('modus-beschreibung');
-    
+
+    const modusSelect = document.getElementById("modus-select");
+    const modusBeschreibung = document.getElementById("modus-beschreibung");
+
     if (modusSelect) {
-        modusSelect.addEventListener('change', function() {
-            const modus = this.value;
-            const isOnline = modus === 'online';
-            
-            // Update description
-            if (modusBeschreibung) {
-                modusBeschreibung.textContent = modusDescriptions[modus] || '';
-            }
-            
-            // Toggle options visibility
-            const hinweisOption = document.getElementById('hinweise-option');
-            const audioOption = document.getElementById('audio-option');
-            
-            if (hinweisOption) hinweisOption.style.display = isOnline ? 'block' : 'none';
-            if (audioOption) audioOption.style.display = isOnline ? 'block' : 'none';
-        });
+      modusSelect.addEventListener("change", function () {
+        const modus = this.value;
+        const isOnline = modus === "online";
+
+        // Update description
+        if (modusBeschreibung) {
+          modusBeschreibung.textContent = modusDescriptions[modus] || "";
+        }
+
+        // Toggle options visibility
+        const hinweisOption = document.getElementById("hinweise-option");
+        const audioOption = document.getElementById("audio-option");
+
+        if (hinweisOption)
+          hinweisOption.style.display = isOnline ? "block" : "none";
+        if (audioOption)
+          audioOption.style.display = isOnline ? "block" : "none";
+      });
     }
-});
+  });
 </script>
 {% endblock %}

--- a/templates/lobby.html
+++ b/templates/lobby.html
@@ -45,8 +45,8 @@
         <div class="card mb-3">
             <div class="card-header" style="display: flex; justify-content: space-between; align-items: center;">
                 <h2 style="font-size: 1.25rem;">
-                    <i class="fa-solid fa-users"></i> Spieler 
-                    <span class="text-muted">(<span id="spieler-anzahl">{{ alle_spieler|length }}</span> / {{ raum.spieler_anzahl }})</span>
+                    <i class="fa-solid fa-users"></i> Spieler
+                    <span class="text-muted">(<span id="spieler-anzahl" data-min="5">{{ alle_spieler|length }}</span> insgesamt, Erzähler zählt nicht für die Mindestanzahl)</span>
                 </h2>
                 <div class="status-indicator" style="
                     display: flex;
@@ -69,7 +69,7 @@
                     display: flex;
                     align-items: center;
                     gap: 0.75rem;
-                " data-spieler-id="{{ s.id }}">
+                " data-spieler-id="{{ s.id }}" data-erzaehler="{{ 'true' if s.ist_erzaehler else 'false' }}">
                     <div style="
                         width: 40px;
                         height: 40px;
@@ -84,7 +84,7 @@
                         {{ s.name[0]|upper }}
                     </div>
                     <div>
-                        <div style="font-weight: 600;">
+                        <div style="font-weight: 600;" class="spielername">
                             {{ s.name }}
                             {% if s.id == spieler.id %}
                             <span class="text-muted">(Du)</span>
@@ -99,6 +99,43 @@
                 </div>
                 {% endfor %}
             </div>
+        </div>
+
+        <!-- Erzähler Auswahl -->
+        <div class="card mb-3" id="erzaehler-card">
+            <div class="card-header" style="display: flex; justify-content: space-between; align-items: center;">
+                <h2 style="font-size: 1.25rem;">
+                    <i class="fa-solid fa-book-open"></i> Erzähler bestimmen
+                </h2>
+                {% if raum.erzaehler_modus == 'zufall' %}
+                <button class="btn btn-primary btn-sm" id="erzaehler-spin-btn" type="button" onclick="spinForErzaehler()">
+                    <i class="fa-solid fa-arrows-spin"></i> Glücksrad
+                </button>
+                {% else %}
+                <span class="badge" style="background: var(--bg-secondary); color: var(--text-secondary);">Glücksrad aus</span>
+                {% endif %}
+            </div>
+            <p class="text-muted" id="erzaehler-status" style="margin-bottom: 0.5rem;">
+                {% if erzaehler %}
+                Erzähler: <strong>{{ erzaehler.name }}</strong>
+                {% elif raum.erzaehler_modus == 'zufall' %}
+                Noch kein Erzähler gewählt. Das Glücksrad sucht einen zufälligen Freiwilligen.
+                {% else %}
+                Erzähler wird ohne Glücksrad vergeben. Legt vor dem Start fest, wer moderiert.
+                {% endif %}
+            </p>
+            {% if raum.erzaehler_modus == 'zufall' %}
+            <div id="erzaehler-wheel" style="height: 80px; display: flex; align-items: center; justify-content: center; gap: 0.5rem; flex-wrap: wrap;">
+                <span class="text-muted">Bereit, das Glücksrad zu drehen?</span>
+            </div>
+            <div class="alert alert-info" style="margin-top: 0.5rem;">
+                Das Glücksrad berücksichtigt nur Spieler, die noch nicht Erzähler sind. Alle sehen live, wer gezogen wird.
+            </div>
+            {% else %}
+            <div class="alert alert-info" style="margin-top: 0.5rem;">
+                Das Glücksrad erscheint nur, wenn ihr beim Setup "Zufälliger Erzähler" gewählt habt.
+            </div>
+            {% endif %}
         </div>
         
         <!-- Sitzordnung - Drag & Drop -->
@@ -335,6 +372,25 @@
         font-weight: bold;
         font-size: 0.9rem;
     }
+
+    .wheel-preview {
+        min-width: 140px;
+        min-height: 48px;
+        padding: 0.5rem 1rem;
+        border-radius: 12px;
+        border: 1px solid var(--border-color);
+        background: radial-gradient(circle at center, rgba(255,255,255,0.08), rgba(0,0,0,0.15));
+        color: var(--text-primary);
+        font-weight: 700;
+        text-align: center;
+        letter-spacing: 0.3px;
+    }
+
+    .wheel-preview.highlight {
+        animation: glow 1s ease-out;
+        border-color: var(--accent-gold);
+        color: var(--accent-gold);
+    }
 </style>
 {% endblock %}
 
@@ -342,6 +398,7 @@
 <script>
     const socket = io();
     const raumCode = "{{ raum.code }}";
+    const erzaehlerModus = "{{ raum.erzaehler_modus }}";
     
     // Raum beitreten
     socket.emit('raum_beitreten', { code: raumCode });
@@ -382,6 +439,11 @@
     socket.on('fehler', function(data) {
         showNotification(data.nachricht, 'error');
     });
+
+    socket.on('erzaehler_gewaehlt', function(data) {
+        updateErzaehlerStatus(data.name);
+        highlightErzaehler(data.spieler_id);
+    });
     
     function addSpielerToList(spieler) {
         const container = document.getElementById('spieler-liste');
@@ -391,6 +453,7 @@
         const karte = document.createElement('div');
         karte.className = 'spieler-karte neu';
         karte.setAttribute('data-spieler-id', spieler.id);
+        karte.setAttribute('data-erzaehler', spieler.ist_erzaehler ? 'true' : 'false');
         karte.style.cssText = `
             background: var(--bg-primary);
             padding: 1rem;
@@ -419,7 +482,7 @@
                 ${spieler.name[0].toUpperCase()}
             </div>
             <div>
-                <div style="font-weight: 600;">${spieler.name}</div>
+                <div style="font-weight: 600;" class="spielername">${spieler.name}</div>
                 ${istErzaehler ? '<div style="font-size: 0.75rem; color: var(--accent-gold);"><i class="fa-solid fa-book-open"></i> Erzähler</div>' : ''}
             </div>
         `;
@@ -441,13 +504,13 @@
         const anzahl = document.getElementById('spieler-anzahl');
         anzahl.textContent = container.querySelectorAll('.spieler-karte').length;
     }
-    
+
     function updateStartButton() {
         const container = document.getElementById('spieler-liste');
-        const anzahl = container.querySelectorAll('.spieler-karte').length;
+        const aktive = container.querySelectorAll('.spieler-karte[data-erzaehler="false"]').length;
         const btnContainer = document.querySelector('.card.text-center');
-        
-        if (anzahl >= 5) {
+
+        if (aktive >= 5) {
             btnContainer.innerHTML = `
                 <p class="text-success mb-2">
                     <i class="fa-solid fa-check-circle"></i> Genügend Spieler vorhanden!
@@ -462,7 +525,7 @@
         } else {
             btnContainer.innerHTML = `
                 <p class="text-muted mb-2">
-                    <i class="fa-solid fa-hourglass-half"></i> Noch ${5 - anzahl} Spieler benötigt...
+                    <i class="fa-solid fa-hourglass-half"></i> Noch ${Math.max(0, 5 - aktive)} Spieler benötigt...
                 </p>
                 <button class="btn btn-ghost btn-lg" disabled>
                     Warte auf Spieler...
@@ -507,7 +570,95 @@
         codeEl.textContent = 'Kopiert!';
         setTimeout(() => codeEl.textContent = original, 1500);
     }
-    
+
+    function updateErzaehlerStatus(name) {
+        const status = document.getElementById('erzaehler-status');
+        status.innerHTML = `Erzähler: <strong>${name}</strong>`;
+    }
+
+    function highlightErzaehler(spielerId) {
+        const karten = document.querySelectorAll('.spieler-karte');
+        karten.forEach(karte => {
+            const istMatch = Number(karte.getAttribute('data-spieler-id')) === Number(spielerId);
+            karte.setAttribute('data-erzaehler', istMatch ? 'true' : 'false');
+            const infoContainer = karte.querySelector('div:nth-child(2)');
+            const bestehend = infoContainer?.querySelector('.erzaehler-badge');
+
+            if (istMatch) {
+                if (!bestehend) {
+                    const label = document.createElement('div');
+                    label.className = 'erzaehler-badge';
+                    label.style.cssText = 'font-size: 0.75rem; color: var(--accent-gold);';
+                    label.innerHTML = '<i class="fa-solid fa-book-open"></i> Erzähler';
+                    infoContainer?.appendChild(label);
+                }
+                karte.style.outline = '2px solid var(--accent-gold)';
+            } else {
+                karte.style.outline = '';
+                bestehend?.remove();
+            }
+        });
+
+        updateSpielerAnzahl();
+        updateStartButton();
+        initSitzordnungFromSpieler();
+    }
+
+    async function spinForErzaehler() {
+        if (erzaehlerModus !== 'zufall') {
+            showNotification('Zufälliger Erzähler ist für dieses Spiel nicht aktiviert.', 'error');
+            return;
+        }
+
+        const button = document.getElementById('erzaehler-spin-btn');
+        const wheel = document.getElementById('erzaehler-wheel');
+
+        if (!button || !wheel) {
+            return;
+        }
+
+        button.disabled = true;
+        button.innerHTML = '<i class="fa-solid fa-arrows-spin fa-spin"></i> läuft...';
+
+        const namen = Array.from(document.querySelectorAll('.spieler-karte[data-erzaehler="false"] .spielername'))
+            .map(el => el.textContent.replace('(Du)', '').trim())
+            .filter(Boolean);
+
+        wheel.innerHTML = '';
+        const preview = document.createElement('div');
+        preview.className = 'wheel-preview';
+        wheel.appendChild(preview);
+
+        let intervalId;
+        if (namen.length > 0) {
+            let index = 0;
+            intervalId = setInterval(() => {
+                preview.textContent = namen[index % namen.length];
+                index += 1;
+            }, 120);
+        }
+
+        try {
+            const response = await fetch(`/api/raum/${raumCode}/erzaehler/random`, { method: 'POST' });
+            const data = await response.json();
+            if (!data.success) {
+                throw new Error(data.error || 'Konnte Erzähler nicht bestimmen');
+            }
+
+            if (intervalId) clearInterval(intervalId);
+
+            preview.textContent = data.erzaehler.name;
+            preview.classList.add('highlight');
+            updateErzaehlerStatus(data.erzaehler.name);
+            highlightErzaehler(data.erzaehler.id);
+        } catch (err) {
+            showNotification(err.message, 'error');
+        } finally {
+            button.disabled = false;
+            button.innerHTML = '<i class="fa-solid fa-arrows-spin"></i> Glücksrad';
+        }
+    }
+
     // ======================================
     // SITZORDNUNG - Drag & Drop System
     // ======================================
@@ -536,7 +687,7 @@
         sitzordnung = [];
         spielerKarten.forEach((karte, index) => {
             const id = parseInt(karte.getAttribute('data-spieler-id'));
-            const name = karte.querySelector('div[style*="font-weight: 600"]')?.textContent?.replace('(Du)', '').trim() || `Spieler ${id}`;
+            const name = karte.querySelector('.spielername')?.textContent?.replace('(Du)', '').trim() || `Spieler ${id}`;
             // Ignoriere Erzähler
             if (!karte.querySelector('.fa-book-open')) {
                 sitzordnung.push({ id, name, sitzplatz: index });
@@ -690,8 +841,12 @@
         sitzordnung.sort((a, b) => a.sitzplatz - b.sitzplatz);
         renderSitzordnung();
     });
-    
+
     // Initialisierung
+    const initialErzaehler = document.querySelector('.spieler-karte[data-erzaehler="true"]');
+    if (initialErzaehler) {
+        highlightErzaehler(initialErzaehler.dataset.spielerId);
+    }
     loadSitzordnung();
 </script>
 {% endblock %}

--- a/templates/lobby.html
+++ b/templates/lobby.html
@@ -1,76 +1,115 @@
-{% extends 'struktur.html' %}
-
-{% block title %}Lobby - {{ raum.name }} | {{ spiel_name }}{% endblock %}
-
-{% block content %}
+{% extends 'struktur.html' %} {% block title %}Lobby - {{ raum.name }} | {{
+spiel_name }}{% endblock %} {% block content %}
 <div class="container">
-    <section class="fade-in" style="max-width: 800px; margin: 0 auto;">
-        
-        <!-- Raum Info -->
-        <div class="card mb-3">
-            <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 1rem;">
-                <div>
-                    <h1 style="font-size: 1.75rem; color: var(--accent-gold);">{{ raum.name }}</h1>
-                    <p class="text-muted">
-                        {% if raum.modus == 'online' %}
-                        <i class="fa-solid fa-wifi"></i> Online-Modus (Automatischer Erzähler)
-                        {% else %}
-                        <i class="fa-solid fa-users"></i> Gruppen-Modus (Mit Erzähler)
-                        {% endif %}
-                    </p>
-                </div>
-                <div class="text-center">
-                    <p class="text-muted mb-1">Raumcode</p>
-                    <div class="room-code" style="
-                        font-family: 'Cinzel', serif;
-                        font-size: 2.5rem;
-                        letter-spacing: 0.3em;
-                        color: var(--accent-red);
-                        background: var(--bg-primary);
-                        padding: 0.5rem 1.5rem;
-                        border-radius: 8px;
-                        border: 2px dashed var(--accent-red);
-                        cursor: pointer;
-                    " onclick="copyCode()" title="Klicken zum Kopieren">
-                        {{ raum.code }}
-                    </div>
-                    <p class="text-muted" style="font-size: 0.75rem; margin-top: 0.5rem;">
-                        Klicken zum Kopieren
-                    </p>
-                </div>
-            </div>
+  <section class="fade-in" style="max-width: 800px; margin: 0 auto">
+    <!-- Raum Info -->
+    <div class="card mb-3">
+      <div
+        style="
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          flex-wrap: wrap;
+          gap: 1rem;
+        "
+      >
+        <div>
+          <h1 style="font-size: 1.75rem; color: var(--accent-gold)">
+            {{ raum.name }}
+          </h1>
+          <p class="text-muted">
+            {% if raum.modus == 'online' %}
+            <i class="fa-solid fa-wifi"></i> Online-Modus (Automatischer
+            Erzähler) {% else %} <i class="fa-solid fa-users"></i> Gruppen-Modus
+            (Mit Erzähler) {% endif %}
+          </p>
         </div>
-        
-        <!-- Spielerliste -->
-        <div class="card mb-3">
-            <div class="card-header" style="display: flex; justify-content: space-between; align-items: center;">
-                <h2 style="font-size: 1.25rem;">
-                    <i class="fa-solid fa-users"></i> Spieler
-                    <span class="text-muted">(<span id="spieler-anzahl" data-min="5">{{ alle_spieler|length }}</span> insgesamt, Erzähler zählt nicht für die Mindestanzahl)</span>
-                </h2>
-                <div class="status-indicator" style="
-                    display: flex;
-                    align-items: center;
-                    gap: 0.5rem;
-                    color: var(--accent-green);
-                ">
-                    <span style="width: 10px; height: 10px; background: var(--accent-green); border-radius: 50%; animation: pulse 2s infinite;"></span>
-                    Warte auf Spieler...
-                </div>
-            </div>
-            
-            <div id="spieler-liste" class="grid grid-3" style="gap: 1rem;">
-                {% for s in alle_spieler %}
-                <div class="spieler-karte" style="
-                    background: var(--bg-primary);
-                    padding: 1rem;
-                    border-radius: 8px;
-                    border: 1px solid var(--border-color);
-                    display: flex;
-                    align-items: center;
-                    gap: 0.75rem;
-                " data-spieler-id="{{ s.id }}" data-erzaehler="{{ 'true' if s.ist_erzaehler else 'false' }}">
-                    <div style="
+        <div class="text-center">
+          <p class="text-muted mb-1">Raumcode</p>
+          <div
+            class="room-code"
+            style="
+              font-family: &quot;Cinzel&quot;, serif;
+              font-size: 2.5rem;
+              letter-spacing: 0.3em;
+              color: var(--accent-red);
+              background: var(--bg-primary);
+              padding: 0.5rem 1.5rem;
+              border-radius: 8px;
+              border: 2px dashed var(--accent-red);
+              cursor: pointer;
+            "
+            onclick="copyCode()"
+            title="Klicken zum Kopieren"
+          >
+            {{ raum.code }}
+          </div>
+          <p class="text-muted" style="font-size: 0.75rem; margin-top: 0.5rem">
+            Klicken zum Kopieren
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Spielerliste -->
+    <div class="card mb-3">
+      <div
+        class="card-header"
+        style="
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+        "
+      >
+        <h2 style="font-size: 1.25rem">
+          <i class="fa-solid fa-users"></i> Spieler
+          <span class="text-muted"
+            >(<span id="spieler-anzahl" data-min="5"
+              >{{ alle_spieler|length }}</span
+            >
+            insgesamt, Erzähler zählt nicht für die Mindestanzahl)</span
+          >
+        </h2>
+        <div
+          class="status-indicator"
+          style="
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            color: var(--accent-green);
+          "
+        >
+          <span
+            style="
+              width: 10px;
+              height: 10px;
+              background: var(--accent-green);
+              border-radius: 50%;
+              animation: pulse 2s infinite;
+            "
+          ></span>
+          Warte auf Spieler...
+        </div>
+      </div>
+
+      <div id="spieler-liste" class="grid grid-3" style="gap: 1rem">
+        {% for s in alle_spieler %}
+        <div
+          class="spieler-karte"
+          style="
+            background: var(--bg-primary);
+            padding: 1rem;
+            border-radius: 8px;
+            border: 1px solid var(--border-color);
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+          "
+          data-spieler-id="{{ s.id }}"
+          data-erzaehler="{{ 'true' if s.ist_erzaehler else 'false' }}"
+        >
+          <div
+            style="
                         width: 40px;
                         height: 40px;
                         background: {{ 'var(--accent-gold)' if s.ist_erzaehler else 'var(--accent-blue)' }};
@@ -80,381 +119,449 @@
                         justify-content: center;
                         font-weight: bold;
                         color: var(--bg-primary);
-                    ">
-                        {{ s.name[0]|upper }}
-                    </div>
-                    <div>
-                        <div style="font-weight: 600;" class="spielername">
-                            {{ s.name }}
-                            {% if s.id == spieler.id %}
-                            <span class="text-muted">(Du)</span>
-                            {% endif %}
-                        </div>
-                        {% if s.ist_erzaehler %}
-                        <div style="font-size: 0.75rem; color: var(--accent-gold);">
-                            <i class="fa-solid fa-book-open"></i> Erzähler
-                        </div>
-                        {% endif %}
-                    </div>
-                </div>
-                {% endfor %}
+                    "
+          >
+            {{ s.name[0]|upper }}
+          </div>
+          <div>
+            <div style="font-weight: 600" class="spielername">
+              {{ s.name }} {% if s.id == spieler.id %}
+              <span class="text-muted">(Du)</span>
+              {% endif %}
             </div>
+            {% if s.ist_erzaehler %}
+            <div style="font-size: 0.75rem; color: var(--accent-gold)">
+              <i class="fa-solid fa-book-open"></i> Erzähler
+            </div>
+            {% endif %}
+          </div>
         </div>
+        {% endfor %}
+      </div>
+    </div>
 
-        <!-- Erzähler Auswahl -->
-        <div class="card mb-3" id="erzaehler-card">
-            <div class="card-header" style="display: flex; justify-content: space-between; align-items: center;">
-                <h2 style="font-size: 1.25rem;">
-                    <i class="fa-solid fa-book-open"></i> Erzähler bestimmen
-                </h2>
-                {% if raum.erzaehler_modus == 'zufall' %}
-                <button class="btn btn-primary btn-sm" id="erzaehler-spin-btn" type="button" onclick="spinForErzaehler()">
-                    <i class="fa-solid fa-arrows-spin"></i> Glücksrad
-                </button>
-                {% else %}
-                <span class="badge" style="background: var(--bg-secondary); color: var(--text-secondary);">Glücksrad aus</span>
-                {% endif %}
-            </div>
-            <p class="text-muted" id="erzaehler-status" style="margin-bottom: 0.5rem;">
-                {% if erzaehler %}
-                Erzähler: <strong>{{ erzaehler.name }}</strong>
-                {% elif raum.erzaehler_modus == 'zufall' %}
-                Noch kein Erzähler gewählt. Das Glücksrad sucht einen zufälligen Freiwilligen.
-                {% else %}
-                Erzähler wird ohne Glücksrad vergeben. Legt vor dem Start fest, wer moderiert.
-                {% endif %}
-            </p>
-            {% if raum.erzaehler_modus == 'zufall' %}
-            <div id="erzaehler-wheel" style="height: 80px; display: flex; align-items: center; justify-content: center; gap: 0.5rem; flex-wrap: wrap;">
-                <span class="text-muted">Bereit, das Glücksrad zu drehen?</span>
-            </div>
-            <div class="alert alert-info" style="margin-top: 0.5rem;">
-                Das Glücksrad berücksichtigt nur Spieler, die noch nicht Erzähler sind. Alle sehen live, wer gezogen wird.
-            </div>
-            {% else %}
-            <div class="alert alert-info" style="margin-top: 0.5rem;">
-                Das Glücksrad erscheint nur, wenn ihr beim Setup "Zufälliger Erzähler" gewählt habt.
-            </div>
-            {% endif %}
+    <!-- Erzähler Auswahl -->
+    <div class="card mb-3" id="erzaehler-card">
+      <div
+        class="card-header"
+        style="
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+        "
+      >
+        <h2 style="font-size: 1.25rem">
+          <i class="fa-solid fa-book-open"></i> Erzähler bestimmen
+        </h2>
+        {% if raum.erzaehler_modus == 'zufall' %}
+        <button
+          class="btn btn-primary btn-sm"
+          id="erzaehler-spin-btn"
+          type="button"
+          onclick="spinForErzaehler()"
+        >
+          <i class="fa-solid fa-arrows-spin"></i> Glücksrad
+        </button>
+        {% else %}
+        <span
+          class="badge"
+          style="background: var(--bg-secondary); color: var(--text-secondary)"
+          >Glücksrad aus</span
+        >
+        {% endif %}
+      </div>
+      <p class="text-muted" id="erzaehler-status" style="margin-bottom: 0.5rem">
+        {% if erzaehler %} Erzähler: <strong>{{ erzaehler.name }}</strong>
+        {% elif raum.erzaehler_modus == 'zufall' %} Noch kein Erzähler gewählt.
+        Das Glücksrad sucht einen zufälligen Freiwilligen. {% else %} Erzähler
+        wird ohne Glücksrad vergeben. Legt vor dem Start fest, wer moderiert. {%
+        endif %}
+      </p>
+      {% if raum.erzaehler_modus == 'zufall' %}
+      <div
+        id="erzaehler-wheel"
+        style="
+          height: 80px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          gap: 0.5rem;
+          flex-wrap: wrap;
+        "
+      >
+        <span class="text-muted">Bereit, das Glücksrad zu drehen?</span>
+      </div>
+      <div class="alert alert-info" style="margin-top: 0.5rem">
+        Das Glücksrad berücksichtigt nur Spieler, die noch nicht Erzähler sind.
+        Alle sehen live, wer gezogen wird.
+      </div>
+      {% else %}
+      <div class="alert alert-info" style="margin-top: 0.5rem">
+        Das Glücksrad erscheint nur, wenn ihr beim Setup "Zufälliger Erzähler"
+        gewählt habt.
+      </div>
+      {% endif %}
+    </div>
+
+    <!-- Sitzordnung - Drag & Drop -->
+    <div class="card mb-3" id="sitzordnung-card">
+      <div
+        class="card-header"
+        style="
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+        "
+      >
+        <h2 style="font-size: 1.25rem">
+          <i class="fa-solid fa-chair"></i> Sitzordnung
+        </h2>
+        <div style="display: flex; gap: 0.5rem">
+          <button
+            class="btn btn-ghost btn-sm"
+            onclick="randomizeSitzordnung()"
+            title="Zufällige Anordnung"
+          >
+            <i class="fa-solid fa-shuffle"></i>
+          </button>
+          <button
+            class="btn btn-ghost btn-sm"
+            onclick="saveSitzordnung()"
+            title="Speichern"
+          >
+            <i class="fa-solid fa-save"></i>
+          </button>
         </div>
-        
-        <!-- Sitzordnung - Drag & Drop -->
-        <div class="card mb-3" id="sitzordnung-card">
-            <div class="card-header" style="display: flex; justify-content: space-between; align-items: center;">
-                <h2 style="font-size: 1.25rem;">
-                    <i class="fa-solid fa-chair"></i> Sitzordnung
-                </h2>
-                <div style="display: flex; gap: 0.5rem;">
-                    <button class="btn btn-ghost btn-sm" onclick="randomizeSitzordnung()" title="Zufällige Anordnung">
-                        <i class="fa-solid fa-shuffle"></i>
-                    </button>
-                    <button class="btn btn-ghost btn-sm" onclick="saveSitzordnung()" title="Speichern">
-                        <i class="fa-solid fa-save"></i>
-                    </button>
-                </div>
-            </div>
-            <p class="text-muted mb-2" style="font-size: 0.875rem;">
-                <i class="fa-solid fa-hand-pointer"></i> Ziehe die Spieler in die Reihenfolge, wie sie physisch nebeneinander sitzen. Die Nachbarn im Kreis sind wichtig für bestimmte Rollen!
-            </p>
-            <div id="sitzordnung-container" class="sitzordnung-kreis">
-                <!-- Wird per JS gefüllt -->
-            </div>
-        </div>
-        
-        <!-- Spielstart -->
-        <div class="card text-center">
-            {% if ist_spiel_bereit %}
-                <p class="text-success mb-2">
-                    <i class="fa-solid fa-check-circle"></i> Genügend Spieler vorhanden!
-                </p>
-                <button id="start-btn" class="btn btn-primary btn-lg" onclick="starteSpiel()">
-                    <i class="fa-solid fa-play"></i> Spiel starten
-                </button>
-            {% else %}
-                <p class="text-muted mb-2">
-                    <i class="fa-solid fa-hourglass-half"></i> Noch {{ fehlende_spieler }} Spieler benötigt...
-                </p>
-                <button class="btn btn-ghost btn-lg" disabled>
-                    Warte auf Spieler...
-                </button>
-            {% endif %}
-            
-            <p class="text-muted mt-3" style="font-size: 0.875rem;">
-                Teile den Raumcode <strong>{{ raum.code }}</strong> mit deinen Freunden!
-            </p>
-        </div>
-        
-        <!-- Rollen Vorschau -->
-        <div class="card mt-3">
-            <h3 class="mb-2" style="font-size: 1rem; color: var(--text-secondary);">
-                <i class="fa-solid fa-masks-theater"></i>
-                Rollenverteilung ({{ rollen_vorschau_total }} Spieler{% if rollen_vorschau_hat_erzaehler %} inkl. Erzähler{% endif %})
-            </h3>
-            <div id="rollen-vorschau" style="display: flex; flex-wrap: wrap; gap: 0.5rem;">
-                {% for rollen_name, anzahl in rollen_vorschau.items() %}
-                    {% set rolle_info = rollen.get(rollen_name, {}) %}
-                    <span style="
+      </div>
+      <p class="text-muted mb-2" style="font-size: 0.875rem">
+        <i class="fa-solid fa-hand-pointer"></i> Ziehe die Spieler in die
+        Reihenfolge, wie sie physisch nebeneinander sitzen. Die Nachbarn im
+        Kreis sind wichtig für bestimmte Rollen!
+      </p>
+      <div id="sitzordnung-container" class="sitzordnung-kreis">
+        <!-- Wird per JS gefüllt -->
+      </div>
+    </div>
+
+    <!-- Spielstart -->
+    <div class="card text-center">
+      {% if ist_spiel_bereit %}
+      <p class="text-success mb-2">
+        <i class="fa-solid fa-check-circle"></i> Genügend Spieler vorhanden!
+      </p>
+      <button
+        id="start-btn"
+        class="btn btn-primary btn-lg"
+        onclick="starteSpiel()"
+      >
+        <i class="fa-solid fa-play"></i> Spiel starten
+      </button>
+      {% else %}
+      <p class="text-muted mb-2">
+        <i class="fa-solid fa-hourglass-half"></i> Noch {{ fehlende_spieler }}
+        Spieler benötigt...
+      </p>
+      <button class="btn btn-ghost btn-lg" disabled>
+        Warte auf Spieler...
+      </button>
+      {% endif %}
+
+      <p class="text-muted mt-3" style="font-size: 0.875rem">
+        Teile den Raumcode <strong>{{ raum.code }}</strong> mit deinen Freunden!
+      </p>
+    </div>
+
+    <!-- Rollen Vorschau -->
+    <div class="card mt-3">
+      <h3 class="mb-2" style="font-size: 1rem; color: var(--text-secondary)">
+        <i class="fa-solid fa-masks-theater"></i>
+        Rollenverteilung ({{ rollen_vorschau_total }} Spieler{% if
+        rollen_vorschau_hat_erzaehler %} inkl. Erzähler{% endif %})
+      </h3>
+      <div
+        id="rollen-vorschau"
+        style="display: flex; flex-wrap: wrap; gap: 0.5rem"
+      >
+        {% for rollen_name, anzahl in rollen_vorschau.items() %} {% set
+        rolle_info = rollen.get(rollen_name, {}) %}
+        <span
+          style="
                         background: {{ rolle_info.get('farbe', 'var(--text-secondary)') }};
                         color: white;
                         padding: 0.25rem 0.75rem;
                         border-radius: 4px;
                         font-size: 0.75rem;
-                    ">
-                        {{ rollen_name }}{% if anzahl > 1 %} x{{ anzahl }}{% endif %}
-                    </span>
-                {% endfor %}
-            </div>
-        </div>
-        
-    </section>
+                    "
+        >
+          {{ rollen_name }}{% if anzahl > 1 %} x{{ anzahl }}{% endif %}
+        </span>
+        {% endfor %}
+      </div>
+    </div>
+  </section>
 </div>
 
 <style>
-    .spieler-karte {
-        animation: fadeIn 0.3s ease-out;
-    }
-    
-    .spieler-karte.neu {
-        animation: fadeIn 0.3s ease-out, glow 0.5s ease-out;
-    }
-    
-    /* Sitzordnung Kreis-Ansicht */
-    .sitzordnung-kreis {
-        position: relative;
-        width: 100%;
-        max-width: 500px;
-        margin: 1rem auto;
-        aspect-ratio: 1;
-        background: radial-gradient(circle at center, var(--bg-secondary) 0%, var(--bg-primary) 70%);
-        border-radius: 50%;
-        border: 2px dashed var(--border-color);
-    }
-    
-    .sitz-slot {
-        position: absolute;
-        width: 70px;
-        height: 70px;
-        transform: translate(-50%, -50%);
-        cursor: grab;
-        transition: transform 0.2s ease, box-shadow 0.2s ease;
-    }
-    
-    .sitz-slot:hover {
-        transform: translate(-50%, -50%) scale(1.1);
-    }
-    
-    .sitz-slot.dragging {
-        cursor: grabbing;
-        opacity: 0.8;
-        z-index: 100;
-        box-shadow: 0 0 20px var(--accent-gold);
-    }
-    
-    .sitz-slot.drag-over {
-        transform: translate(-50%, -50%) scale(1.15);
-        box-shadow: 0 0 15px var(--accent-blue);
-    }
-    
-    .sitz-avatar {
-        width: 100%;
-        height: 100%;
-        border-radius: 50%;
-        background: var(--accent-blue);
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        color: white;
-        font-weight: bold;
-        font-size: 1.5rem;
-        border: 3px solid var(--border-color);
-        box-shadow: 0 4px 12px rgba(0,0,0,0.3);
-    }
-    
-    .sitz-avatar .sitz-name {
-        font-size: 0.65rem;
-        margin-top: 2px;
-        max-width: 60px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-    }
-    
-    .sitz-avatar .sitz-nummer {
-        position: absolute;
-        top: -5px;
-        right: -5px;
-        width: 20px;
-        height: 20px;
-        background: var(--accent-gold);
-        color: var(--bg-primary);
-        border-radius: 50%;
-        font-size: 0.7rem;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-    }
-    
-    .sitz-dorf-mitte {
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%);
-        width: 80px;
-        height: 80px;
-        background: var(--bg-card);
-        border: 2px solid var(--accent-gold);
-        border-radius: 50%;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        color: var(--accent-gold);
-        font-size: 2rem;
-    }
-    
-    /* Drag & Drop Liste als Fallback */
-    .sitzordnung-liste {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.5rem;
-        padding: 1rem;
-        min-height: 60px;
-        border: 2px dashed var(--border-color);
-        border-radius: 8px;
-        background: var(--bg-primary);
-    }
-    
-    .sitz-chip {
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-        padding: 0.5rem 1rem;
-        background: var(--bg-card);
-        border: 1px solid var(--border-color);
-        border-radius: 20px;
-        cursor: grab;
-        transition: all 0.2s ease;
-        user-select: none;
-    }
-    
-    .sitz-chip:hover {
-        border-color: var(--accent-gold);
-        transform: translateY(-2px);
-    }
-    
-    .sitz-chip.dragging {
-        opacity: 0.5;
-        cursor: grabbing;
-    }
-    
-    .sitz-chip .chip-nummer {
-        width: 24px;
-        height: 24px;
-        background: var(--accent-gold);
-        color: var(--bg-primary);
-        border-radius: 50%;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        font-size: 0.75rem;
-        font-weight: bold;
-    }
-    
-    .sitz-chip .chip-avatar {
-        width: 28px;
-        height: 28px;
-        background: var(--accent-blue);
-        color: white;
-        border-radius: 50%;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        font-weight: bold;
-        font-size: 0.9rem;
-    }
+  .spieler-karte {
+    animation: fadeIn 0.3s ease-out;
+  }
 
-    .wheel-preview {
-        min-width: 140px;
-        min-height: 48px;
-        padding: 0.5rem 1rem;
-        border-radius: 12px;
-        border: 1px solid var(--border-color);
-        background: radial-gradient(circle at center, rgba(255,255,255,0.08), rgba(0,0,0,0.15));
-        color: var(--text-primary);
-        font-weight: 700;
-        text-align: center;
-        letter-spacing: 0.3px;
-    }
+  .spieler-karte.neu {
+    animation:
+      fadeIn 0.3s ease-out,
+      glow 0.5s ease-out;
+  }
 
-    .wheel-preview.highlight {
-        animation: glow 1s ease-out;
-        border-color: var(--accent-gold);
-        color: var(--accent-gold);
-    }
+  /* Sitzordnung Kreis-Ansicht */
+  .sitzordnung-kreis {
+    position: relative;
+    width: 100%;
+    max-width: 500px;
+    margin: 1rem auto;
+    aspect-ratio: 1;
+    background: radial-gradient(
+      circle at center,
+      var(--bg-secondary) 0%,
+      var(--bg-primary) 70%
+    );
+    border-radius: 50%;
+    border: 2px dashed var(--border-color);
+  }
+
+  .sitz-slot {
+    position: absolute;
+    width: 70px;
+    height: 70px;
+    transform: translate(-50%, -50%);
+    cursor: grab;
+    transition:
+      transform 0.2s ease,
+      box-shadow 0.2s ease;
+  }
+
+  .sitz-slot:hover {
+    transform: translate(-50%, -50%) scale(1.1);
+  }
+
+  .sitz-slot.dragging {
+    cursor: grabbing;
+    opacity: 0.8;
+    z-index: 100;
+    box-shadow: 0 0 20px var(--accent-gold);
+  }
+
+  .sitz-slot.drag-over {
+    transform: translate(-50%, -50%) scale(1.15);
+    box-shadow: 0 0 15px var(--accent-blue);
+  }
+
+  .sitz-avatar {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    background: var(--accent-blue);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    font-weight: bold;
+    font-size: 1.5rem;
+    border: 3px solid var(--border-color);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  }
+
+  .sitz-avatar .sitz-name {
+    font-size: 0.65rem;
+    margin-top: 2px;
+    max-width: 60px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .sitz-avatar .sitz-nummer {
+    position: absolute;
+    top: -5px;
+    right: -5px;
+    width: 20px;
+    height: 20px;
+    background: var(--accent-gold);
+    color: var(--bg-primary);
+    border-radius: 50%;
+    font-size: 0.7rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .sitz-dorf-mitte {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 80px;
+    height: 80px;
+    background: var(--bg-card);
+    border: 2px solid var(--accent-gold);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--accent-gold);
+    font-size: 2rem;
+  }
+
+  /* Drag & Drop Liste als Fallback */
+  .sitzordnung-liste {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    padding: 1rem;
+    min-height: 60px;
+    border: 2px dashed var(--border-color);
+    border-radius: 8px;
+    background: var(--bg-primary);
+  }
+
+  .sitz-chip {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: 20px;
+    cursor: grab;
+    transition: all 0.2s ease;
+    user-select: none;
+  }
+
+  .sitz-chip:hover {
+    border-color: var(--accent-gold);
+    transform: translateY(-2px);
+  }
+
+  .sitz-chip.dragging {
+    opacity: 0.5;
+    cursor: grabbing;
+  }
+
+  .sitz-chip .chip-nummer {
+    width: 24px;
+    height: 24px;
+    background: var(--accent-gold);
+    color: var(--bg-primary);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.75rem;
+    font-weight: bold;
+  }
+
+  .sitz-chip .chip-avatar {
+    width: 28px;
+    height: 28px;
+    background: var(--accent-blue);
+    color: white;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: bold;
+    font-size: 0.9rem;
+  }
+
+  .wheel-preview {
+    min-width: 140px;
+    min-height: 48px;
+    padding: 0.5rem 1rem;
+    border-radius: 12px;
+    border: 1px solid var(--border-color);
+    background: radial-gradient(
+      circle at center,
+      rgba(255, 255, 255, 0.08),
+      rgba(0, 0, 0, 0.15)
+    );
+    color: var(--text-primary);
+    font-weight: 700;
+    text-align: center;
+    letter-spacing: 0.3px;
+  }
+
+  .wheel-preview.highlight {
+    animation: glow 1s ease-out;
+    border-color: var(--accent-gold);
+    color: var(--accent-gold);
+  }
 </style>
-{% endblock %}
-
-{% block scripts %}
+{% endblock %} {% block scripts %}
 <script>
-    const socket = io();
-    const raumCode = "{{ raum.code }}";
-    const erzaehlerModus = "{{ raum.erzaehler_modus }}";
-    
-    // Raum beitreten
-    socket.emit('raum_beitreten', { code: raumCode });
-    
-    // Spielerliste aktualisieren
-    socket.on('spieler_liste', function(data) {
-        updateSpielerListe(data.spieler);
-    });
-    
-    socket.on('spieler_verbunden', function(data) {
-        // Neuen Spieler dynamisch zur Liste hinzufügen
-        addSpielerToList(data.spieler);
-        updateSpielerAnzahl();
-        updateStartButton();
-        updateRollenVorschau();
-        // Auch zur Sitzordnung hinzufügen
-        addToSitzordnung(data.spieler);
-    });
-    
-    socket.on('spieler_getrennt', function(data) {
-        // Spieler aus Liste entfernen
-        removeSpielerFromList(data.spieler_id);
-        updateSpielerAnzahl();
-        updateStartButton();
-        updateRollenVorschau();
-        // Auch aus Sitzordnung entfernen
-        removeFromSitzordnung(data.spieler_id);
-    });
-    
-    socket.on('spiel_gestartet', function(data) {
-        socket.emit('navigiere', { ziel: '/spiel/' + raumCode });
-    });
-    
-    socket.on('navigiere', function(data) {
-        window.location.href = data.ziel;
-    });
-    
-    socket.on('fehler', function(data) {
-        showNotification(data.nachricht, 'error');
-    });
+  const socket = io();
+  const raumCode = "{{ raum.code }}";
+  const erzaehlerModus = "{{ raum.erzaehler_modus }}";
 
-    socket.on('erzaehler_gewaehlt', function(data) {
-        updateErzaehlerStatus(data.name);
-        highlightErzaehler(data.spieler_id);
-    });
-    
-    function addSpielerToList(spieler) {
-        const container = document.getElementById('spieler-liste');
-        const existierend = container.querySelector(`[data-spieler-id="${spieler.id}"]`);
-        if (existierend) return; // Bereits vorhanden
-        
-        const karte = document.createElement('div');
-        karte.className = 'spieler-karte neu';
-        karte.setAttribute('data-spieler-id', spieler.id);
-        karte.setAttribute('data-erzaehler', spieler.ist_erzaehler ? 'true' : 'false');
-        karte.style.cssText = `
+  // Raum beitreten
+  socket.emit("raum_beitreten", { code: raumCode });
+
+  // Spielerliste aktualisieren
+  socket.on("spieler_liste", function (data) {
+    updateSpielerListe(data.spieler);
+  });
+
+  socket.on("spieler_verbunden", function (data) {
+    // Neuen Spieler dynamisch zur Liste hinzufügen
+    addSpielerToList(data.spieler);
+    updateSpielerAnzahl();
+    updateStartButton();
+    updateRollenVorschau();
+    // Auch zur Sitzordnung hinzufügen
+    addToSitzordnung(data.spieler);
+  });
+
+  socket.on("spieler_getrennt", function (data) {
+    // Spieler aus Liste entfernen
+    removeSpielerFromList(data.spieler_id);
+    updateSpielerAnzahl();
+    updateStartButton();
+    updateRollenVorschau();
+    // Auch aus Sitzordnung entfernen
+    removeFromSitzordnung(data.spieler_id);
+  });
+
+  socket.on("spiel_gestartet", function (data) {
+    socket.emit("navigiere", { ziel: "/spiel/" + raumCode });
+  });
+
+  socket.on("navigiere", function (data) {
+    window.location.href = data.ziel;
+  });
+
+  socket.on("fehler", function (data) {
+    showNotification(data.nachricht, "error");
+  });
+
+  socket.on("erzaehler_gewaehlt", function (data) {
+    updateErzaehlerStatus(data.name);
+    highlightErzaehler(data.spieler_id);
+  });
+
+  function addSpielerToList(spieler) {
+    const container = document.getElementById("spieler-liste");
+    const existierend = container.querySelector(
+      `[data-spieler-id="${spieler.id}"]`,
+    );
+    if (existierend) return; // Bereits vorhanden
+
+    const karte = document.createElement("div");
+    karte.className = "spieler-karte neu";
+    karte.setAttribute("data-spieler-id", spieler.id);
+    karte.setAttribute(
+      "data-erzaehler",
+      spieler.ist_erzaehler ? "true" : "false",
+    );
+    karte.style.cssText = `
             background: var(--bg-primary);
             padding: 1rem;
             border-radius: 8px;
@@ -463,11 +570,11 @@
             align-items: center;
             gap: 0.75rem;
         `;
-        
-        const istErzaehler = spieler.ist_erzaehler;
-        const farbe = istErzaehler ? 'var(--accent-gold)' : 'var(--accent-blue)';
-        
-        karte.innerHTML = `
+
+    const istErzaehler = spieler.ist_erzaehler;
+    const farbe = istErzaehler ? "var(--accent-gold)" : "var(--accent-blue)";
+
+    karte.innerHTML = `
             <div style="
                 width: 40px;
                 height: 40px;
@@ -483,35 +590,37 @@
             </div>
             <div>
                 <div style="font-weight: 600;" class="spielername">${spieler.name}</div>
-                ${istErzaehler ? '<div style="font-size: 0.75rem; color: var(--accent-gold);"><i class="fa-solid fa-book-open"></i> Erzähler</div>' : ''}
+                ${istErzaehler ? '<div style="font-size: 0.75rem; color: var(--accent-gold);"><i class="fa-solid fa-book-open"></i> Erzähler</div>' : ""}
             </div>
         `;
-        
-        container.appendChild(karte);
-    }
-    
-    function removeSpielerFromList(spielerId) {
-        const container = document.getElementById('spieler-liste');
-        const karte = container.querySelector(`[data-spieler-id="${spielerId}"]`);
-        if (karte) {
-            karte.style.animation = 'fadeOut 0.3s ease-out';
-            setTimeout(() => karte.remove(), 300);
-        }
-    }
-    
-    function updateSpielerAnzahl() {
-        const container = document.getElementById('spieler-liste');
-        const anzahl = document.getElementById('spieler-anzahl');
-        anzahl.textContent = container.querySelectorAll('.spieler-karte').length;
-    }
 
-    function updateStartButton() {
-        const container = document.getElementById('spieler-liste');
-        const aktive = container.querySelectorAll('.spieler-karte[data-erzaehler="false"]').length;
-        const btnContainer = document.querySelector('.card.text-center');
+    container.appendChild(karte);
+  }
 
-        if (aktive >= 5) {
-            btnContainer.innerHTML = `
+  function removeSpielerFromList(spielerId) {
+    const container = document.getElementById("spieler-liste");
+    const karte = container.querySelector(`[data-spieler-id="${spielerId}"]`);
+    if (karte) {
+      karte.style.animation = "fadeOut 0.3s ease-out";
+      setTimeout(() => karte.remove(), 300);
+    }
+  }
+
+  function updateSpielerAnzahl() {
+    const container = document.getElementById("spieler-liste");
+    const anzahl = document.getElementById("spieler-anzahl");
+    anzahl.textContent = container.querySelectorAll(".spieler-karte").length;
+  }
+
+  function updateStartButton() {
+    const container = document.getElementById("spieler-liste");
+    const aktive = container.querySelectorAll(
+      '.spieler-karte[data-erzaehler="false"]',
+    ).length;
+    const btnContainer = document.querySelector(".card.text-center");
+
+    if (aktive >= 5) {
+      btnContainer.innerHTML = `
                 <p class="text-success mb-2">
                     <i class="fa-solid fa-check-circle"></i> Genügend Spieler vorhanden!
                 </p>
@@ -522,8 +631,8 @@
                     Teile den Raumcode <strong>${raumCode}</strong> mit deinen Freunden!
                 </p>
             `;
-        } else {
-            btnContainer.innerHTML = `
+    } else {
+      btnContainer.innerHTML = `
                 <p class="text-muted mb-2">
                     <i class="fa-solid fa-hourglass-half"></i> Noch ${Math.max(0, 5 - aktive)} Spieler benötigt...
                 </p>
@@ -534,185 +643,201 @@
                     Teile den Raumcode <strong>${raumCode}</strong> mit deinen Freunden!
                 </p>
             `;
-        }
     }
-    
-    function showNotification(msg, type) {
-        const notification = document.createElement('div');
-        notification.className = `notification ${type}`;
-        notification.textContent = msg;
-        notification.style.cssText = `
+  }
+
+  function showNotification(msg, type) {
+    const notification = document.createElement("div");
+    notification.className = `notification ${type}`;
+    notification.textContent = msg;
+    notification.style.cssText = `
             position: fixed;
             top: 20px;
             right: 20px;
             padding: 1rem 2rem;
-            background: ${type === 'error' ? 'var(--accent-red)' : 'var(--accent-green)'};
+            background: ${type === "error" ? "var(--accent-red)" : "var(--accent-green)"};
             color: white;
             border-radius: 8px;
             z-index: 1000;
             animation: fadeIn 0.3s ease-out;
         `;
-        document.body.appendChild(notification);
-        setTimeout(() => notification.remove(), 3000);
-    }
-    
-    function starteSpiel() {
-        const btn = document.getElementById('start-btn');
-        btn.disabled = true;
-        btn.textContent = 'Starte...';
-        socket.emit('spiel_starten', {});
-    }
-    
-    function copyCode() {
-        navigator.clipboard.writeText(raumCode);
-        const codeEl = document.querySelector('.room-code');
-        const original = codeEl.textContent;
-        codeEl.textContent = 'Kopiert!';
-        setTimeout(() => codeEl.textContent = original, 1500);
-    }
+    document.body.appendChild(notification);
+    setTimeout(() => notification.remove(), 3000);
+  }
 
-    function updateErzaehlerStatus(name) {
-        const status = document.getElementById('erzaehler-status');
-        status.innerHTML = `Erzähler: <strong>${name}</strong>`;
-    }
+  function starteSpiel() {
+    const btn = document.getElementById("start-btn");
+    btn.disabled = true;
+    btn.textContent = "Starte...";
+    socket.emit("spiel_starten", {});
+  }
 
-    function highlightErzaehler(spielerId) {
-        const karten = document.querySelectorAll('.spieler-karte');
-        karten.forEach(karte => {
-            const istMatch = Number(karte.getAttribute('data-spieler-id')) === Number(spielerId);
-            karte.setAttribute('data-erzaehler', istMatch ? 'true' : 'false');
-            const infoContainer = karte.querySelector('div:nth-child(2)');
-            const bestehend = infoContainer?.querySelector('.erzaehler-badge');
+  function copyCode() {
+    navigator.clipboard.writeText(raumCode);
+    const codeEl = document.querySelector(".room-code");
+    const original = codeEl.textContent;
+    codeEl.textContent = "Kopiert!";
+    setTimeout(() => (codeEl.textContent = original), 1500);
+  }
 
-            if (istMatch) {
-                if (!bestehend) {
-                    const label = document.createElement('div');
-                    label.className = 'erzaehler-badge';
-                    label.style.cssText = 'font-size: 0.75rem; color: var(--accent-gold);';
-                    label.innerHTML = '<i class="fa-solid fa-book-open"></i> Erzähler';
-                    infoContainer?.appendChild(label);
-                }
-                karte.style.outline = '2px solid var(--accent-gold)';
-            } else {
-                karte.style.outline = '';
-                bestehend?.remove();
-            }
-        });
+  function updateErzaehlerStatus(name) {
+    const status = document.getElementById("erzaehler-status");
+    status.innerHTML = `Erzähler: <strong>${name}</strong>`;
+  }
 
-        updateSpielerAnzahl();
-        updateStartButton();
-        initSitzordnungFromSpieler();
-    }
+  function highlightErzaehler(spielerId) {
+    const karten = document.querySelectorAll(".spieler-karte");
+    karten.forEach((karte) => {
+      const istMatch =
+        Number(karte.getAttribute("data-spieler-id")) === Number(spielerId);
+      karte.setAttribute("data-erzaehler", istMatch ? "true" : "false");
+      const infoContainer = karte.querySelector("div:nth-child(2)");
+      const bestehend = infoContainer?.querySelector(".erzaehler-badge");
 
-    async function spinForErzaehler() {
-        if (erzaehlerModus !== 'zufall') {
-            showNotification('Zufälliger Erzähler ist für dieses Spiel nicht aktiviert.', 'error');
-            return;
+      if (istMatch) {
+        if (!bestehend) {
+          const label = document.createElement("div");
+          label.className = "erzaehler-badge";
+          label.style.cssText =
+            "font-size: 0.75rem; color: var(--accent-gold);";
+          label.innerHTML = '<i class="fa-solid fa-book-open"></i> Erzähler';
+          infoContainer?.appendChild(label);
         }
+        karte.style.outline = "2px solid var(--accent-gold)";
+      } else {
+        karte.style.outline = "";
+        bestehend?.remove();
+      }
+    });
 
-        const button = document.getElementById('erzaehler-spin-btn');
-        const wheel = document.getElementById('erzaehler-wheel');
+    updateSpielerAnzahl();
+    updateStartButton();
+    initSitzordnungFromSpieler();
+  }
 
-        if (!button || !wheel) {
-            return;
-        }
-
-        button.disabled = true;
-        button.innerHTML = '<i class="fa-solid fa-arrows-spin fa-spin"></i> läuft...';
-
-        const namen = Array.from(document.querySelectorAll('.spieler-karte[data-erzaehler="false"] .spielername'))
-            .map(el => el.textContent.replace('(Du)', '').trim())
-            .filter(Boolean);
-
-        wheel.innerHTML = '';
-        const preview = document.createElement('div');
-        preview.className = 'wheel-preview';
-        wheel.appendChild(preview);
-
-        let intervalId;
-        if (namen.length > 0) {
-            let index = 0;
-            intervalId = setInterval(() => {
-                preview.textContent = namen[index % namen.length];
-                index += 1;
-            }, 120);
-        }
-
-        try {
-            const response = await fetch(`/api/raum/${raumCode}/erzaehler/random`, { method: 'POST' });
-            const data = await response.json();
-            if (!data.success) {
-                throw new Error(data.error || 'Konnte Erzähler nicht bestimmen');
-            }
-
-            if (intervalId) clearInterval(intervalId);
-
-            preview.textContent = data.erzaehler.name;
-            preview.classList.add('highlight');
-            updateErzaehlerStatus(data.erzaehler.name);
-            highlightErzaehler(data.erzaehler.id);
-        } catch (err) {
-            showNotification(err.message, 'error');
-        } finally {
-            button.disabled = false;
-            button.innerHTML = '<i class="fa-solid fa-arrows-spin"></i> Glücksrad';
-        }
+  async function spinForErzaehler() {
+    if (erzaehlerModus !== "zufall") {
+      showNotification(
+        "Zufälliger Erzähler ist für dieses Spiel nicht aktiviert.",
+        "error",
+      );
+      return;
     }
 
-    // ======================================
-    // SITZORDNUNG - Drag & Drop System
-    // ======================================
-    
-    let sitzordnung = []; // {id, name, sitzplatz}
-    let draggedElement = null;
-    
-    // Initiale Sitzordnung laden
-    async function loadSitzordnung() {
-        try {
-            const response = await fetch(`/api/sitzordnung/${raumCode}`);
-            const data = await response.json();
-            if (data.success) {
-                sitzordnung = data.sitzordnung;
-                renderSitzordnung();
-            }
-        } catch (e) {
-            console.error('Fehler beim Laden der Sitzordnung:', e);
-            // Fallback: Spielerliste als Sitzordnung
-            initSitzordnungFromSpieler();
-        }
+    const button = document.getElementById("erzaehler-spin-btn");
+    const wheel = document.getElementById("erzaehler-wheel");
+
+    if (!button || !wheel) {
+      return;
     }
-    
-    function initSitzordnungFromSpieler() {
-        const spielerKarten = document.querySelectorAll('.spieler-karte');
-        sitzordnung = [];
-        spielerKarten.forEach((karte, index) => {
-            const id = parseInt(karte.getAttribute('data-spieler-id'));
-            const name = karte.querySelector('.spielername')?.textContent?.replace('(Du)', '').trim() || `Spieler ${id}`;
-            // Ignoriere Erzähler
-            if (!karte.querySelector('.fa-book-open')) {
-                sitzordnung.push({ id, name, sitzplatz: index });
-            }
-        });
+
+    button.disabled = true;
+    button.innerHTML =
+      '<i class="fa-solid fa-arrows-spin fa-spin"></i> läuft...';
+
+    const namen = Array.from(
+      document.querySelectorAll(
+        '.spieler-karte[data-erzaehler="false"] .spielername',
+      ),
+    )
+      .map((el) => el.textContent.replace("(Du)", "").trim())
+      .filter(Boolean);
+
+    wheel.innerHTML = "";
+    const preview = document.createElement("div");
+    preview.className = "wheel-preview";
+    wheel.appendChild(preview);
+
+    let intervalId;
+    if (namen.length > 0) {
+      let index = 0;
+      intervalId = setInterval(() => {
+        preview.textContent = namen[index % namen.length];
+        index += 1;
+      }, 120);
+    }
+
+    try {
+      const response = await fetch(`/api/raum/${raumCode}/erzaehler/random`, {
+        method: "POST",
+      });
+      const data = await response.json();
+      if (!data.success) {
+        throw new Error(data.error || "Konnte Erzähler nicht bestimmen");
+      }
+
+      if (intervalId) clearInterval(intervalId);
+
+      preview.textContent = data.erzaehler.name;
+      preview.classList.add("highlight");
+      updateErzaehlerStatus(data.erzaehler.name);
+      highlightErzaehler(data.erzaehler.id);
+    } catch (err) {
+      showNotification(err.message, "error");
+    } finally {
+      button.disabled = false;
+      button.innerHTML = '<i class="fa-solid fa-arrows-spin"></i> Glücksrad';
+    }
+  }
+
+  // ======================================
+  // SITZORDNUNG - Drag & Drop System
+  // ======================================
+
+  let sitzordnung = []; // {id, name, sitzplatz}
+  let draggedElement = null;
+
+  // Initiale Sitzordnung laden
+  async function loadSitzordnung() {
+    try {
+      const response = await fetch(`/api/sitzordnung/${raumCode}`);
+      const data = await response.json();
+      if (data.success) {
+        sitzordnung = data.sitzordnung;
         renderSitzordnung();
+      }
+    } catch (e) {
+      console.error("Fehler beim Laden der Sitzordnung:", e);
+      // Fallback: Spielerliste als Sitzordnung
+      initSitzordnungFromSpieler();
     }
-    
-    function renderSitzordnung() {
-        const container = document.getElementById('sitzordnung-container');
-        if (!container || sitzordnung.length === 0) return;
-        
-        const anzahl = sitzordnung.length;
-        const radius = 42; // Prozent vom Container
-        
-        // Dorf-Mitte
-        let html = `<div class="sitz-dorf-mitte"><i class="fa-solid fa-campfire"></i></div>`;
-        
-        // Spieler im Kreis positionieren
-        sitzordnung.forEach((spieler, index) => {
-            const winkel = (index / anzahl) * 2 * Math.PI - Math.PI / 2;
-            const x = 50 + radius * Math.cos(winkel);
-            const y = 50 + radius * Math.sin(winkel);
-            
-            html += `
+  }
+
+  function initSitzordnungFromSpieler() {
+    const spielerKarten = document.querySelectorAll(".spieler-karte");
+    sitzordnung = [];
+    spielerKarten.forEach((karte, index) => {
+      const id = parseInt(karte.getAttribute("data-spieler-id"));
+      const name =
+        karte
+          .querySelector(".spielername")
+          ?.textContent?.replace("(Du)", "")
+          .trim() || `Spieler ${id}`;
+      // Ignoriere Erzähler
+      if (!karte.querySelector(".fa-book-open")) {
+        sitzordnung.push({ id, name, sitzplatz: index });
+      }
+    });
+    renderSitzordnung();
+  }
+
+  function renderSitzordnung() {
+    const container = document.getElementById("sitzordnung-container");
+    if (!container || sitzordnung.length === 0) return;
+
+    const anzahl = sitzordnung.length;
+    const radius = 42; // Prozent vom Container
+
+    // Dorf-Mitte
+    let html = `<div class="sitz-dorf-mitte"><i class="fa-solid fa-campfire"></i></div>`;
+
+    // Spieler im Kreis positionieren
+    sitzordnung.forEach((spieler, index) => {
+      const winkel = (index / anzahl) * 2 * Math.PI - Math.PI / 2;
+      const x = 50 + radius * Math.cos(winkel);
+      const y = 50 + radius * Math.sin(winkel);
+
+      html += `
                 <div class="sitz-slot" 
                      data-id="${spieler.id}" 
                      data-index="${index}"
@@ -729,124 +854,129 @@
                     </div>
                 </div>
             `;
-        });
-        
-        container.innerHTML = html;
-    }
-    
-    function handleDragStart(e) {
-        draggedElement = e.target.closest('.sitz-slot');
-        draggedElement.classList.add('dragging');
-        e.dataTransfer.effectAllowed = 'move';
-        e.dataTransfer.setData('text/plain', draggedElement.dataset.index);
-    }
-    
-    function handleDragOver(e) {
-        e.preventDefault();
-        e.dataTransfer.dropEffect = 'move';
-        const slot = e.target.closest('.sitz-slot');
-        if (slot && slot !== draggedElement) {
-            slot.classList.add('drag-over');
-        }
-    }
-    
-    function handleDrop(e) {
-        e.preventDefault();
-        const targetSlot = e.target.closest('.sitz-slot');
-        if (!targetSlot || targetSlot === draggedElement) return;
-        
-        targetSlot.classList.remove('drag-over');
-        
-        const fromIndex = parseInt(draggedElement.dataset.index);
-        const toIndex = parseInt(targetSlot.dataset.index);
-        
-        // Swap positions in array
-        [sitzordnung[fromIndex], sitzordnung[toIndex]] = [sitzordnung[toIndex], sitzordnung[fromIndex]];
-        
-        // Update sitzplatz values
-        sitzordnung.forEach((s, i) => s.sitzplatz = i);
-        
-        renderSitzordnung();
-        saveSitzordnung();
-    }
-    
-    function handleDragEnd(e) {
-        document.querySelectorAll('.sitz-slot').forEach(slot => {
-            slot.classList.remove('dragging', 'drag-over');
-        });
-        draggedElement = null;
-    }
-    
-    function addToSitzordnung(spieler) {
-        // Nur hinzufügen wenn nicht Erzähler und noch nicht vorhanden
-        if (spieler.ist_erzaehler) return;
-        if (sitzordnung.find(s => s.id === spieler.id)) return;
-        
-        sitzordnung.push({
-            id: spieler.id,
-            name: spieler.name,
-            sitzplatz: sitzordnung.length
-        });
-        renderSitzordnung();
-        saveSitzordnung();
-    }
-    
-    function removeFromSitzordnung(spielerId) {
-        const index = sitzordnung.findIndex(s => s.id === spielerId);
-        if (index === -1) return;
-        
-        sitzordnung.splice(index, 1);
-        // Sitzplätze neu vergeben
-        sitzordnung.forEach((s, i) => s.sitzplatz = i);
-        renderSitzordnung();
-        saveSitzordnung();
-    }
-    
-    function randomizeSitzordnung() {
-        // Fisher-Yates shuffle
-        for (let i = sitzordnung.length - 1; i > 0; i--) {
-            const j = Math.floor(Math.random() * (i + 1));
-            [sitzordnung[i], sitzordnung[j]] = [sitzordnung[j], sitzordnung[i]];
-        }
-        sitzordnung.forEach((s, i) => s.sitzplatz = i);
-        renderSitzordnung();
-        saveSitzordnung();
-        showNotification('Sitzordnung gemischt!', 'success');
-    }
-    
-    async function saveSitzordnung() {
-        try {
-            const ordnung = sitzordnung.map((s, i) => ({ id: s.id, sitzplatz: i }));
-            const response = await fetch(`/api/sitzordnung/${raumCode}`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ ordnung })
-            });
-            const data = await response.json();
-            if (!data.success) {
-                console.error('Speichern fehlgeschlagen:', data.error);
-            }
-        } catch (e) {
-            console.error('Fehler beim Speichern:', e);
-        }
-    }
-    
-    // Socket-Events für Sitzordnung
-    socket.on('sitzordnung_aktualisiert', function(data) {
-        // Aktualisiere lokale Sitzordnung basierend auf Server-Daten
-        data.ordnung.forEach(update => {
-            const spieler = sitzordnung.find(s => s.id === update.id);
-            if (spieler) spieler.sitzplatz = update.sitzplatz;
-        });
-        sitzordnung.sort((a, b) => a.sitzplatz - b.sitzplatz);
-        renderSitzordnung();
     });
 
-    // Initialisierung
-    const initialErzaehler = document.querySelector('.spieler-karte[data-erzaehler="true"]');
-    if (initialErzaehler) {
-        highlightErzaehler(initialErzaehler.dataset.spielerId);
+    container.innerHTML = html;
+  }
+
+  function handleDragStart(e) {
+    draggedElement = e.target.closest(".sitz-slot");
+    draggedElement.classList.add("dragging");
+    e.dataTransfer.effectAllowed = "move";
+    e.dataTransfer.setData("text/plain", draggedElement.dataset.index);
+  }
+
+  function handleDragOver(e) {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+    const slot = e.target.closest(".sitz-slot");
+    if (slot && slot !== draggedElement) {
+      slot.classList.add("drag-over");
     }
-    loadSitzordnung();
+  }
+
+  function handleDrop(e) {
+    e.preventDefault();
+    const targetSlot = e.target.closest(".sitz-slot");
+    if (!targetSlot || targetSlot === draggedElement) return;
+
+    targetSlot.classList.remove("drag-over");
+
+    const fromIndex = parseInt(draggedElement.dataset.index);
+    const toIndex = parseInt(targetSlot.dataset.index);
+
+    // Swap positions in array
+    [sitzordnung[fromIndex], sitzordnung[toIndex]] = [
+      sitzordnung[toIndex],
+      sitzordnung[fromIndex],
+    ];
+
+    // Update sitzplatz values
+    sitzordnung.forEach((s, i) => (s.sitzplatz = i));
+
+    renderSitzordnung();
+    saveSitzordnung();
+  }
+
+  function handleDragEnd(e) {
+    document.querySelectorAll(".sitz-slot").forEach((slot) => {
+      slot.classList.remove("dragging", "drag-over");
+    });
+    draggedElement = null;
+  }
+
+  function addToSitzordnung(spieler) {
+    // Nur hinzufügen wenn nicht Erzähler und noch nicht vorhanden
+    if (spieler.ist_erzaehler) return;
+    if (sitzordnung.find((s) => s.id === spieler.id)) return;
+
+    sitzordnung.push({
+      id: spieler.id,
+      name: spieler.name,
+      sitzplatz: sitzordnung.length,
+    });
+    renderSitzordnung();
+    saveSitzordnung();
+  }
+
+  function removeFromSitzordnung(spielerId) {
+    const index = sitzordnung.findIndex((s) => s.id === spielerId);
+    if (index === -1) return;
+
+    sitzordnung.splice(index, 1);
+    // Sitzplätze neu vergeben
+    sitzordnung.forEach((s, i) => (s.sitzplatz = i));
+    renderSitzordnung();
+    saveSitzordnung();
+  }
+
+  function randomizeSitzordnung() {
+    // Fisher-Yates shuffle
+    for (let i = sitzordnung.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [sitzordnung[i], sitzordnung[j]] = [sitzordnung[j], sitzordnung[i]];
+    }
+    sitzordnung.forEach((s, i) => (s.sitzplatz = i));
+    renderSitzordnung();
+    saveSitzordnung();
+    showNotification("Sitzordnung gemischt!", "success");
+  }
+
+  async function saveSitzordnung() {
+    try {
+      const ordnung = sitzordnung.map((s, i) => ({ id: s.id, sitzplatz: i }));
+      const response = await fetch(`/api/sitzordnung/${raumCode}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ordnung }),
+      });
+      const data = await response.json();
+      if (!data.success) {
+        console.error("Speichern fehlgeschlagen:", data.error);
+      }
+    } catch (e) {
+      console.error("Fehler beim Speichern:", e);
+    }
+  }
+
+  // Socket-Events für Sitzordnung
+  socket.on("sitzordnung_aktualisiert", function (data) {
+    // Aktualisiere lokale Sitzordnung basierend auf Server-Daten
+    data.ordnung.forEach((update) => {
+      const spieler = sitzordnung.find((s) => s.id === update.id);
+      if (spieler) spieler.sitzplatz = update.sitzplatz;
+    });
+    sitzordnung.sort((a, b) => a.sitzplatz - b.sitzplatz);
+    renderSitzordnung();
+  });
+
+  // Initialisierung
+  const initialErzaehler = document.querySelector(
+    '.spieler-karte[data-erzaehler="true"]',
+  );
+  if (initialErzaehler) {
+    highlightErzaehler(initialErzaehler.dataset.spielerId);
+  }
+  loadSitzordnung();
 </script>
 {% endblock %}

--- a/tests/test_dynamic_phase_mapping.py
+++ b/tests/test_dynamic_phase_mapping.py
@@ -7,21 +7,21 @@ class DynamicPhaseMappingTests(unittest.TestCase):
     def test_registry_driven_mapping_includes_core_roles(self):
         mapping = phasennamen_zu_rollen_mapping()
 
-        self.assertIn('werwolf_phase', mapping)
-        self.assertEqual(mapping['werwolf_phase'], 'Werwolf')
+        self.assertIn("werwolf_phase", mapping)
+        self.assertEqual(mapping["werwolf_phase"], "Werwolf")
 
-        self.assertIn('seherin_phase', mapping)
-        self.assertEqual(mapping['seherin_phase'], 'Seherin')
+        self.assertIn("seherin_phase", mapping)
+        self.assertEqual(mapping["seherin_phase"], "Seherin")
 
     def test_umlaut_names_are_normalized(self):
         mapping = phasennamen_zu_rollen_mapping()
 
         # Umlaut-Varianten müssen in den PHASEN-Schlüsselraum übersetzt werden.
-        self.assertIn('jaeger_phase', mapping)
-        self.assertEqual(mapping['jaeger_phase'], 'Jäger')
+        self.assertIn("jaeger_phase", mapping)
+        self.assertEqual(mapping["jaeger_phase"], "Jäger")
 
-        self.assertIn('weisser_wolf_phase', mapping)
-        self.assertEqual(mapping['weisser_wolf_phase'], 'Weißer Wolf')
+        self.assertIn("weisser_wolf_phase", mapping)
+        self.assertEqual(mapping["weisser_wolf_phase"], "Weißer Wolf")
 
     def test_mapping_only_contains_known_phases(self):
         mapping = phasennamen_zu_rollen_mapping()
@@ -30,5 +30,5 @@ class DynamicPhaseMappingTests(unittest.TestCase):
             self.assertIn(phase_name, PHASEN)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_dynamic_phase_mapping.py
+++ b/tests/test_dynamic_phase_mapping.py
@@ -1,0 +1,34 @@
+import unittest
+
+from game_logic import PHASEN, phasennamen_zu_rollen_mapping
+
+
+class DynamicPhaseMappingTests(unittest.TestCase):
+    def test_registry_driven_mapping_includes_core_roles(self):
+        mapping = phasennamen_zu_rollen_mapping()
+
+        self.assertIn('werwolf_phase', mapping)
+        self.assertEqual(mapping['werwolf_phase'], 'Werwolf')
+
+        self.assertIn('seherin_phase', mapping)
+        self.assertEqual(mapping['seherin_phase'], 'Seherin')
+
+    def test_umlaut_names_are_normalized(self):
+        mapping = phasennamen_zu_rollen_mapping()
+
+        # Umlaut-Varianten müssen in den PHASEN-Schlüsselraum übersetzt werden.
+        self.assertIn('jaeger_phase', mapping)
+        self.assertEqual(mapping['jaeger_phase'], 'Jäger')
+
+        self.assertIn('weisser_wolf_phase', mapping)
+        self.assertEqual(mapping['weisser_wolf_phase'], 'Weißer Wolf')
+
+    def test_mapping_only_contains_known_phases(self):
+        mapping = phasennamen_zu_rollen_mapping()
+
+        for phase_name in mapping.keys():
+            self.assertIn(phase_name, PHASEN)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_game_logic_full_cycle.py
+++ b/tests/test_game_logic_full_cycle.py
@@ -18,7 +18,8 @@ import unittest
 from flask import Flask
 
 import game_logic
-from models import PHASEN, Raum, Spieler, db
+from game_logic import PHASEN
+from models import Raum, Spieler, db
 
 
 def _build_test_app() -> Flask:

--- a/tests/test_game_logic_full_cycle.py
+++ b/tests/test_game_logic_full_cycle.py
@@ -25,8 +25,8 @@ def _build_test_app() -> Flask:
     """Create a fresh Flask app with an in-memory database for each test."""
 
     app = Flask(__name__)
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
-    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 
     db.init_app(app)
     with app.app_context():
@@ -52,20 +52,20 @@ class GameLogicFullCycleTest(unittest.TestCase):
 
         # Minimum counts for roles that should appear as groups.
         special_counts = {
-            'Zwei Schwestern': 2,
-            'Drei Brüder': 3,
-            'Freimaurer': 3,
-            'Werwolf': 2,  # Keeps the wolf phase meaningful.
+            "Zwei Schwestern": 2,
+            "Drei Brüder": 3,
+            "Freimaurer": 3,
+            "Werwolf": 2,  # Keeps the wolf phase meaningful.
         }
 
         with self.app.app_context():
             raum = Raum(
-                code='TST123',
-                name='Full Cycle',
-                modus='online',
+                code="TST123",
+                name="Full Cycle",
+                modus="online",
                 spieler_anzahl=0,
                 spiel_gestartet=True,
-                aktuelle_phase='nacht_start',
+                aktuelle_phase="nacht_start",
                 runde=1,
             )
             db.session.add(raum)
@@ -83,7 +83,7 @@ class GameLogicFullCycleTest(unittest.TestCase):
                             raum_id=raum.id,
                             rolle=role,
                             ist_am_leben=True,
-                            status='aktiv',
+                            status="aktiv",
                         )
                     )
 
@@ -94,7 +94,9 @@ class GameLogicFullCycleTest(unittest.TestCase):
 
     def test_all_roles_advance_through_all_actions(self):
         raum_id = self._create_full_room()
-        expected_order = PHASEN[PHASEN.index('dieb_phase'): PHASEN.index('tag_ende') + 1]
+        expected_order = PHASEN[
+            PHASEN.index("dieb_phase") : PHASEN.index("tag_ende") + 1
+        ]
 
         with self.app.app_context():
             raum = Raum.query.get(raum_id)
@@ -103,7 +105,7 @@ class GameLogicFullCycleTest(unittest.TestCase):
 
             # Ensure every mapped action belongs to a known phase and key role gates the wolf attack.
             self.assertTrue(set(phase_roles.keys()).issubset(set(PHASEN)))
-            self.assertEqual(phase_roles.get('werwolf_phase'), 'Werwolf')
+            self.assertEqual(phase_roles.get("werwolf_phase"), "Werwolf")
 
             for _ in range(len(expected_order)):
                 next_phase = game_logic.naechste_phase(raum)
@@ -122,22 +124,24 @@ class GameLogicFullCycleTest(unittest.TestCase):
                         raum.id,
                         raum.runde,
                         next_phase,
-                        'test_action',
+                        "test_action",
                         actor.id,
                         target_id,
                     )
 
                 self.assertTrue(
-                    game_logic.alle_haben_gewaehlt(raum, next_phase, acting_role if acting_role else None)
+                    game_logic.alle_haben_gewaehlt(
+                        raum, next_phase, acting_role if acting_role else None
+                    )
                 )
 
-                if next_phase == 'tag_ende':
+                if next_phase == "tag_ende":
                     break
 
         self.assertEqual(expected_order[: len(visited)], visited)
         self.assertEqual(raum.runde, 1)
-        self.assertEqual(raum.aktuelle_phase, 'tag_ende')
+        self.assertEqual(raum.aktuelle_phase, "tag_ende")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_game_logic_full_cycle.py
+++ b/tests/test_game_logic_full_cycle.py
@@ -1,0 +1,143 @@
+"""Integration-style tests for the core game logic.
+
+This suite builds a large room with every role that unlocks a dedicated
+phase so we can assert that:
+
+* `naechste_phase` does not skip any night/day steps when the matching role
+  exists.
+* `registriere_aktion` + `alle_haben_gewaehlt` can record inputs from all
+  relevant players in heavy games.
+
+The test isolates the logic in an in-memory SQLite database and does not
+touch the production `app.py` database setup.
+"""
+
+from __future__ import annotations
+
+import unittest
+from flask import Flask
+
+import game_logic
+from models import PHASEN, Raum, Spieler, db
+
+
+def _build_test_app() -> Flask:
+    """Create a fresh Flask app with an in-memory database for each test."""
+
+    app = Flask(__name__)
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+    db.init_app(app)
+    with app.app_context():
+        db.create_all()
+
+    return app
+
+
+class GameLogicFullCycleTest(unittest.TestCase):
+    """Walk through every phase with all matching roles present."""
+
+    def setUp(self):
+        self.app = _build_test_app()
+
+    def tearDown(self):
+        with self.app.app_context():
+            db.session.remove()
+
+    def _create_full_room(self) -> int:
+        """Populate a room with one player for each mapped phase role."""
+
+        phase_roles = game_logic.phasennamen_zu_rollen_mapping()
+
+        # Minimum counts for roles that should appear as groups.
+        special_counts = {
+            'Zwei Schwestern': 2,
+            'Drei Brüder': 3,
+            'Freimaurer': 3,
+            'Werwolf': 2,  # Keeps the wolf phase meaningful.
+        }
+
+        with self.app.app_context():
+            raum = Raum(
+                code='TST123',
+                name='Full Cycle',
+                modus='online',
+                spieler_anzahl=0,
+                spiel_gestartet=True,
+                aktuelle_phase='nacht_start',
+                runde=1,
+            )
+            db.session.add(raum)
+            db.session.flush()
+
+            players: list[Spieler] = []
+
+            for role in sorted(set(phase_roles.values())):
+                count = special_counts.get(role, 1)
+                for idx in range(count):
+                    players.append(
+                        Spieler(
+                            name=f"{role}-{idx + 1}",
+                            session_id=f"sess-{role}-{idx}",
+                            raum_id=raum.id,
+                            rolle=role,
+                            ist_am_leben=True,
+                            status='aktiv',
+                        )
+                    )
+
+            db.session.add_all(players)
+            raum.spieler_anzahl = len(players)
+            db.session.commit()
+            return raum.id
+
+    def test_all_roles_advance_through_all_actions(self):
+        raum_id = self._create_full_room()
+        expected_order = PHASEN[PHASEN.index('dieb_phase'): PHASEN.index('tag_ende') + 1]
+
+        with self.app.app_context():
+            raum = Raum.query.get(raum_id)
+            visited: list[str] = []
+            phase_roles = game_logic.phasennamen_zu_rollen_mapping()
+
+            # Ensure every mapped action belongs to a known phase and key role gates the wolf attack.
+            self.assertTrue(set(phase_roles.keys()).issubset(set(PHASEN)))
+            self.assertEqual(phase_roles.get('werwolf_phase'), 'Werwolf')
+
+            for _ in range(len(expected_order)):
+                next_phase = game_logic.naechste_phase(raum)
+                visited.append(next_phase)
+
+                acting_role = phase_roles.get(next_phase)
+                if acting_role:
+                    actors = game_logic.hole_spieler_fuer_rolle(raum, acting_role)
+                else:
+                    actors = game_logic.hole_lebende_spieler(raum)
+
+                # Register one action per actor to mimic a busy round.
+                for actor in actors:
+                    target_id = actors[0].id if actors else None
+                    game_logic.registriere_aktion(
+                        raum.id,
+                        raum.runde,
+                        next_phase,
+                        'test_action',
+                        actor.id,
+                        target_id,
+                    )
+
+                self.assertTrue(
+                    game_logic.alle_haben_gewaehlt(raum, next_phase, acting_role if acting_role else None)
+                )
+
+                if next_phase == 'tag_ende':
+                    break
+
+        self.assertEqual(expected_order[: len(visited)], visited)
+        self.assertEqual(raum.runde, 1)
+        self.assertEqual(raum.aktuelle_phase, 'tag_ende')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/village_renderer.py
+++ b/village_renderer.py
@@ -35,20 +35,21 @@ CIRCLE_CENTER = (VILLAGE_WIDTH // 2, VILLAGE_HEIGHT // 2 + 50)
 
 # Farben
 FARBEN = {
-    'feuer': [(255, 100, 0), (255, 150, 50), (255, 200, 100), (255, 80, 0)],
-    'mond': (255, 255, 200),
-    'schatten': (0, 0, 0, 150),
-    'lebendig': (100, 130, 200),
-    'tot': (80, 80, 90),
-    'werwolf_hint': (200, 50, 50),
-    'dorf_hint': (100, 200, 100),
-    'mystisch': (150, 100, 200),
+    "feuer": [(255, 100, 0), (255, 150, 50), (255, 200, 100), (255, 80, 0)],
+    "mond": (255, 255, 200),
+    "schatten": (0, 0, 0, 150),
+    "lebendig": (100, 130, 200),
+    "tot": (80, 80, 90),
+    "werwolf_hint": (200, 50, 50),
+    "dorf_hint": (100, 200, 100),
+    "mystisch": (150, 100, 200),
 }
 
 
 @dataclass
 class SpielerVisual:
     """Visuelle Repräsentation eines Spielers"""
+
     id: int
     name: str
     sitzplatz: int
@@ -61,94 +62,103 @@ class SpielerVisual:
 @dataclass
 class DorfSzene:
     """Komplette Dorfszene für Rendering"""
+
     spieler: List[SpielerVisual]
     phase: str  # 'nacht', 'tag', 'daemmerung'
     runde: int
-    aktive_hinweise: Dict[int, Tuple[str, float]]  # spieler_id -> (hinweis_typ, intensität)
-    wetter: str = 'klar'  # 'klar', 'nebel', 'sturm'
+    aktive_hinweise: Dict[
+        int, Tuple[str, float]
+    ]  # spieler_id -> (hinweis_typ, intensität)
+    wetter: str = "klar"  # 'klar', 'nebel', 'sturm'
 
 
 class VillageRenderer:
     """
     Server-Side 3D Village Renderer
-    
+
     Rendert das Dorf komplett auf dem Server.
     Der Client erhält NUR das fertige Bild - KEINEN Zugriff auf Spielzustand!
     """
-    
+
     def __init__(self):
         self.width = VILLAGE_WIDTH
         self.height = VILLAGE_HEIGHT
-        
+
         # Cache für Sprites (in Produktion: Vorgeladene PNGs)
         self._sprite_cache = {}
-        
+
         # Font für Namen (Fallback auf Default)
         try:
-            self._font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 14)
-            self._font_small = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 10)
+            self._font = ImageFont.truetype(
+                "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 14
+            )
+            self._font_small = ImageFont.truetype(
+                "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 10
+            )
         except:
             self._font = ImageFont.load_default()
             self._font_small = self._font
-    
+
     def render_szene(self, szene: DorfSzene) -> bytes:
         """
         Rendert eine komplette Dorfszene und gibt PNG-Bytes zurück.
-        
+
         Args:
             szene: DorfSzene mit allen öffentlichen Informationen
-            
+
         Returns:
             PNG-Bilddaten als Bytes
         """
         # Erstelle Bild
-        img = Image.new('RGBA', (self.width, self.height), BACKGROUND_COLOR + (255,))
+        img = Image.new("RGBA", (self.width, self.height), BACKGROUND_COLOR + (255,))
         draw = ImageDraw.Draw(img)
-        
+
         # 1. Himmel rendern (basierend auf Phase)
         self._render_himmel(img, draw, szene.phase)
-        
+
         # 2. Mond/Sonne rendern
-        if szene.phase == 'nacht':
+        if szene.phase == "nacht":
             self._render_mond(img, draw)
-        elif szene.phase == 'tag':
+        elif szene.phase == "tag":
             self._render_sonne(img, draw)
-        
+
         # 3. Boden rendern (isometrische Ellipse)
         self._render_boden(img, draw)
-        
+
         # 4. Lagerfeuer rendern
         self._render_lagerfeuer(img, draw, szene.phase)
-        
+
         # 5. Spieler rendern (von hinten nach vorne für korrekte Überlappung)
         spieler_sortiert = self._sortiere_spieler_fuer_rendering(szene.spieler)
         total_spieler = max(len(szene.spieler), 8)
         for spieler in spieler_sortiert:
             hinweis = szene.aktive_hinweise.get(spieler.id)
-            self._render_spieler(img, draw, spieler, szene.phase, hinweis, total_spieler)
-        
+            self._render_spieler(
+                img, draw, spieler, szene.phase, hinweis, total_spieler
+            )
+
         # 6. Atmosphären-Effekte
-        if szene.wetter == 'nebel':
+        if szene.wetter == "nebel":
             self._render_nebel(img)
-        
+
         # 7. Overlay für Nacht
-        if szene.phase == 'nacht':
+        if szene.phase == "nacht":
             self._render_nacht_overlay(img)
-        
+
         # In PNG konvertieren
         buffer = io.BytesIO()
-        img.save(buffer, format='PNG', optimize=True)
+        img.save(buffer, format="PNG", optimize=True)
         return buffer.getvalue()
-    
+
     def render_szene_base64(self, szene: DorfSzene) -> str:
         """Rendert Szene und gibt Base64-String für HTML img src zurück"""
         png_bytes = self.render_szene(szene)
-        b64 = base64.b64encode(png_bytes).decode('utf-8')
+        b64 = base64.b64encode(png_bytes).decode("utf-8")
         return f"data:image/png;base64,{b64}"
-    
+
     def _render_himmel(self, img: Image.Image, draw: ImageDraw.Draw, phase: str):
         """Rendert den Himmel-Gradienten"""
-        if phase == 'nacht':
+        if phase == "nacht":
             # Dunkler Nachthimmel mit Sternen
             for y in range(self.height // 2):
                 # Gradient von dunkelblau nach schwarz
@@ -157,16 +167,19 @@ class VillageRenderer:
                 g = int(10 + ratio * 15)
                 b = int(30 + ratio * 20)
                 draw.line([(0, y), (self.width, y)], fill=(r, g, b))
-            
+
             # Sterne
             for _ in range(50):
                 x = random.randint(0, self.width)
                 y = random.randint(0, self.height // 2)
                 brightness = random.randint(150, 255)
                 size = random.choice([1, 1, 1, 2])
-                draw.ellipse([x, y, x + size, y + size], fill=(brightness, brightness, brightness))
-                
-        elif phase == 'tag':
+                draw.ellipse(
+                    [x, y, x + size, y + size],
+                    fill=(brightness, brightness, brightness),
+                )
+
+        elif phase == "tag":
             # Heller Tageshimmel
             for y in range(self.height // 2):
                 ratio = y / (self.height // 2)
@@ -182,43 +195,55 @@ class VillageRenderer:
                 g = int(50 + ratio * 80)
                 b = int(100 + ratio * 50)
                 draw.line([(0, y), (self.width, y)], fill=(r, g, b))
-    
+
     def _render_mond(self, img: Image.Image, draw: ImageDraw.Draw):
         """Rendert den Mond"""
         mond_x, mond_y = self.width - 120, 80
         mond_radius = 40
-        
+
         # Mondschein-Glow
         for i in range(20, 0, -1):
             alpha = int(30 * (1 - i / 20))
             glow_color = (255, 255, 200, alpha)
             # Erstelle temporäres Bild für Alpha-Blending
-            glow = Image.new('RGBA', img.size, (0, 0, 0, 0))
+            glow = Image.new("RGBA", img.size, (0, 0, 0, 0))
             glow_draw = ImageDraw.Draw(glow)
-            glow_draw.ellipse([
-                mond_x - mond_radius - i * 3,
-                mond_y - mond_radius - i * 3,
-                mond_x + mond_radius + i * 3,
-                mond_y + mond_radius + i * 3
-            ], fill=glow_color)
+            glow_draw.ellipse(
+                [
+                    mond_x - mond_radius - i * 3,
+                    mond_y - mond_radius - i * 3,
+                    mond_x + mond_radius + i * 3,
+                    mond_y + mond_radius + i * 3,
+                ],
+                fill=glow_color,
+            )
             img.paste(Image.alpha_composite(img, glow))
-        
+
         # Mond selbst
-        draw.ellipse([
-            mond_x - mond_radius, mond_y - mond_radius,
-            mond_x + mond_radius, mond_y + mond_radius
-        ], fill=FARBEN['mond'])
-        
+        draw.ellipse(
+            [
+                mond_x - mond_radius,
+                mond_y - mond_radius,
+                mond_x + mond_radius,
+                mond_y + mond_radius,
+            ],
+            fill=FARBEN["mond"],
+        )
+
         # Mondkrater (dunklere Flecken)
-        krater_positionen = [(mond_x - 10, mond_y - 5), (mond_x + 15, mond_y + 10), (mond_x - 5, mond_y + 15)]
+        krater_positionen = [
+            (mond_x - 10, mond_y - 5),
+            (mond_x + 15, mond_y + 10),
+            (mond_x - 5, mond_y + 15),
+        ]
         for kx, ky in krater_positionen:
             draw.ellipse([kx - 5, ky - 5, kx + 5, ky + 5], fill=(220, 220, 180))
-    
+
     def _render_sonne(self, img: Image.Image, draw: ImageDraw.Draw):
         """Rendert die Sonne"""
         sonne_x, sonne_y = 100, 80
         sonne_radius = 35
-        
+
         # Sonnenstrahlen
         for i in range(12):
             winkel = i * 30 * math.pi / 180
@@ -226,49 +251,67 @@ class VillageRenderer:
             start_y = sonne_y + math.sin(winkel) * (sonne_radius + 10)
             end_x = sonne_x + math.cos(winkel) * (sonne_radius + 30)
             end_y = sonne_y + math.sin(winkel) * (sonne_radius + 30)
-            draw.line([(start_x, start_y), (end_x, end_y)], fill=(255, 220, 100), width=3)
-        
+            draw.line(
+                [(start_x, start_y), (end_x, end_y)], fill=(255, 220, 100), width=3
+            )
+
         # Sonne selbst
-        draw.ellipse([
-            sonne_x - sonne_radius, sonne_y - sonne_radius,
-            sonne_x + sonne_radius, sonne_y + sonne_radius
-        ], fill=(255, 230, 120))
-    
+        draw.ellipse(
+            [
+                sonne_x - sonne_radius,
+                sonne_y - sonne_radius,
+                sonne_x + sonne_radius,
+                sonne_y + sonne_radius,
+            ],
+            fill=(255, 230, 120),
+        )
+
     def _render_boden(self, img: Image.Image, draw: ImageDraw.Draw):
         """Rendert den isometrischen Boden"""
         cx, cy = CIRCLE_CENTER
-        
+
         # Äußerer Grasbereich
-        draw.ellipse([
-            cx - CIRCLE_RADIUS - 80,
-            cy - (CIRCLE_RADIUS + 80) * ISO_SCALE_Y,
-            cx + CIRCLE_RADIUS + 80,
-            cy + (CIRCLE_RADIUS + 80) * ISO_SCALE_Y
-        ], fill=(40, 60, 40))
-        
+        draw.ellipse(
+            [
+                cx - CIRCLE_RADIUS - 80,
+                cy - (CIRCLE_RADIUS + 80) * ISO_SCALE_Y,
+                cx + CIRCLE_RADIUS + 80,
+                cy + (CIRCLE_RADIUS + 80) * ISO_SCALE_Y,
+            ],
+            fill=(40, 60, 40),
+        )
+
         # Innerer Erdbereich
-        draw.ellipse([
-            cx - CIRCLE_RADIUS - 20,
-            cy - (CIRCLE_RADIUS + 20) * ISO_SCALE_Y,
-            cx + CIRCLE_RADIUS + 20,
-            cy + (CIRCLE_RADIUS + 20) * ISO_SCALE_Y
-        ], fill=GROUND_COLOR)
-        
+        draw.ellipse(
+            [
+                cx - CIRCLE_RADIUS - 20,
+                cy - (CIRCLE_RADIUS + 20) * ISO_SCALE_Y,
+                cx + CIRCLE_RADIUS + 20,
+                cy + (CIRCLE_RADIUS + 20) * ISO_SCALE_Y,
+            ],
+            fill=GROUND_COLOR,
+        )
+
         # Steinkreis um das Feuer
         for i in range(16):
             winkel = i * 22.5 * math.pi / 180
             x = cx + math.cos(winkel) * 50
             y = cy + math.sin(winkel) * 50 * ISO_SCALE_Y
             stein_groesse = random.randint(6, 10)
-            draw.ellipse([
-                x - stein_groesse, y - stein_groesse // 2,
-                x + stein_groesse, y + stein_groesse // 2
-            ], fill=(60, 60, 65))
-    
+            draw.ellipse(
+                [
+                    x - stein_groesse,
+                    y - stein_groesse // 2,
+                    x + stein_groesse,
+                    y + stein_groesse // 2,
+                ],
+                fill=(60, 60, 65),
+            )
+
     def _render_lagerfeuer(self, img: Image.Image, draw: ImageDraw.Draw, phase: str):
         """Rendert das Lagerfeuer"""
         cx, cy = CIRCLE_CENTER
-        
+
         # Holzscheite
         for i in range(5):
             winkel = i * 72 * math.pi / 180
@@ -277,9 +320,9 @@ class VillageRenderer:
             x2 = cx + math.cos(winkel + 0.5) * 25
             y2 = cy + math.sin(winkel + 0.5) * 25 * ISO_SCALE_Y - 5
             draw.line([(x1, y1), (x2, y2)], fill=(80, 50, 30), width=6)
-        
+
         # Feuer (nur nachts und in Dämmerung sichtbar)
-        if phase != 'tag':
+        if phase != "tag":
             # Flammen-Basis
             flammen_punkte = [
                 (cx - 20, cy),
@@ -289,7 +332,7 @@ class VillageRenderer:
                 (cx + 20, cy),
             ]
             draw.polygon(flammen_punkte, fill=(255, 100, 0))
-            
+
             # Innere Flamme
             innere_punkte = [
                 (cx - 10, cy - 5),
@@ -299,27 +342,29 @@ class VillageRenderer:
                 (cx + 10, cy - 5),
             ]
             draw.polygon(innere_punkte, fill=(255, 180, 50))
-            
+
             # Kern
             draw.ellipse([cx - 5, cy - 20, cx + 5, cy - 10], fill=(255, 255, 150))
-            
+
             # Feuerschein auf Boden
-            glow = Image.new('RGBA', img.size, (0, 0, 0, 0))
+            glow = Image.new("RGBA", img.size, (0, 0, 0, 0))
             glow_draw = ImageDraw.Draw(glow)
-            glow_draw.ellipse([
-                cx - 60, cy - 30,
-                cx + 60, cy + 30
-            ], fill=(255, 150, 50, 40))
+            glow_draw.ellipse(
+                [cx - 60, cy - 30, cx + 60, cy + 30], fill=(255, 150, 50, 40)
+            )
             img.paste(Image.alpha_composite(img, glow))
-    
-    def _sortiere_spieler_fuer_rendering(self, spieler: List[SpielerVisual]) -> List[SpielerVisual]:
+
+    def _sortiere_spieler_fuer_rendering(
+        self, spieler: List[SpielerVisual]
+    ) -> List[SpielerVisual]:
         """Sortiert Spieler von hinten nach vorne für korrekte Überlappung"""
+
         def y_position(s: SpielerVisual) -> float:
             winkel = (s.sitzplatz / max(len(spieler), 8)) * 2 * math.pi - math.pi / 2
             return math.sin(winkel)
-        
+
         return sorted(spieler, key=y_position)
-    
+
     def _render_spieler(
         self,
         img: Image.Image,
@@ -327,7 +372,7 @@ class VillageRenderer:
         spieler: SpielerVisual,
         phase: str,
         hinweis: Optional[Tuple[str, float]] = None,
-        total_spieler: int = 8
+        total_spieler: int = 8,
     ):
         """Rendert einen einzelnen Spieler"""
         anzahl = max(total_spieler, 8)
@@ -340,139 +385,188 @@ class VillageRenderer:
         y = cy + math.sin(winkel) * radius * ISO_SCALE_Y
 
         scale = 0.7 + 0.5 * tiefenfaktor
-        
+
         # Schatten
         if spieler.ist_am_leben:
-            draw.ellipse([x - 15 * scale, y + 25 * scale, x + 15 * scale, y + 35 * scale], fill=(0, 0, 0, 80))
-        
+            draw.ellipse(
+                [x - 15 * scale, y + 25 * scale, x + 15 * scale, y + 35 * scale],
+                fill=(0, 0, 0, 80),
+            )
+
         # Körper-Farbe basierend auf Zustand
         if not spieler.ist_am_leben:
-            koerper_farbe = FARBEN['tot']
+            koerper_farbe = FARBEN["tot"]
         else:
-            koerper_farbe = FARBEN['lebendig']
-        
+            koerper_farbe = FARBEN["lebendig"]
+
         # Hinweis-Effekt
         if hinweis and spieler.ist_am_leben:
             hinweis_typ, intensitaet = hinweis
-            koerper_farbe = self._apply_hinweis_farbe(koerper_farbe, hinweis_typ, intensitaet)
-        
+            koerper_farbe = self._apply_hinweis_farbe(
+                koerper_farbe, hinweis_typ, intensitaet
+            )
+
         if spieler.ist_am_leben:
             # Lebender Spieler - stehend
-            
+
             # Körper (Robe)
             robe_punkte = [
                 (x - 12 * scale, y + 25 * scale),  # Unten links
-                (x - 15 * scale, y - 5 * scale),   # Taille links
-                (x - 8 * scale, y - 25 * scale),   # Schulter links
-                (x, y - 30 * scale),       # Kopf-Ansatz
-                (x + 8 * scale, y - 25 * scale),   # Schulter rechts
-                (x + 15 * scale, y - 5 * scale),   # Taille rechts
+                (x - 15 * scale, y - 5 * scale),  # Taille links
+                (x - 8 * scale, y - 25 * scale),  # Schulter links
+                (x, y - 30 * scale),  # Kopf-Ansatz
+                (x + 8 * scale, y - 25 * scale),  # Schulter rechts
+                (x + 15 * scale, y - 5 * scale),  # Taille rechts
                 (x + 12 * scale, y + 25 * scale),  # Unten rechts
             ]
             draw.polygon(robe_punkte, fill=koerper_farbe, outline=(50, 50, 60))
 
             # Kopf
             kopf_y = y - 40 * scale
-            draw.ellipse([x - 10 * scale, kopf_y - 10 * scale, x + 10 * scale, kopf_y + 10 * scale], fill=(220, 185, 155))
-            
+            draw.ellipse(
+                [
+                    x - 10 * scale,
+                    kopf_y - 10 * scale,
+                    x + 10 * scale,
+                    kopf_y + 10 * scale,
+                ],
+                fill=(220, 185, 155),
+            )
+
             # Augen (schauen zum Feuer)
             feuer_richtung = math.atan2(cy - kopf_y, cx - x)
             auge_offset_x = math.cos(feuer_richtung) * 3 * scale
-            draw.ellipse([x - 4 * scale + auge_offset_x, kopf_y - 2 * scale, x - 2 * scale + auge_offset_x, kopf_y + 2 * scale], fill=(40, 40, 40))
-            draw.ellipse([x + 2 * scale + auge_offset_x, kopf_y - 2 * scale, x + 4 * scale + auge_offset_x, kopf_y + 2 * scale], fill=(40, 40, 40))
-            
+            draw.ellipse(
+                [
+                    x - 4 * scale + auge_offset_x,
+                    kopf_y - 2 * scale,
+                    x - 2 * scale + auge_offset_x,
+                    kopf_y + 2 * scale,
+                ],
+                fill=(40, 40, 40),
+            )
+            draw.ellipse(
+                [
+                    x + 2 * scale + auge_offset_x,
+                    kopf_y - 2 * scale,
+                    x + 4 * scale + auge_offset_x,
+                    kopf_y + 2 * scale,
+                ],
+                fill=(40, 40, 40),
+            )
+
             # Hinweis-Glow um Spieler
             if hinweis:
                 self._render_hinweis_effekt(img, draw, x, y, hinweis)
         else:
             # Toter Spieler - liegend
-            draw.ellipse([x - 20 * scale, y + 10 * scale, x + 20 * scale, y + 30 * scale], fill=koerper_farbe)
+            draw.ellipse(
+                [x - 20 * scale, y + 10 * scale, x + 20 * scale, y + 30 * scale],
+                fill=koerper_farbe,
+            )
             # X über den Augen
-            draw.line([(x - 8 * scale, y + 15 * scale), (x - 2 * scale, y + 21 * scale)], fill=(100, 50, 50), width=2)
-            draw.line([(x - 8 * scale, y + 21 * scale), (x - 2 * scale, y + 15 * scale)], fill=(100, 50, 50), width=2)
-            draw.line([(x + 2 * scale, y + 15 * scale), (x + 8 * scale, y + 21 * scale)], fill=(100, 50, 50), width=2)
-            draw.line([(x + 2 * scale, y + 21 * scale), (x + 8 * scale, y + 15 * scale)], fill=(100, 50, 50), width=2)
-        
+            draw.line(
+                [(x - 8 * scale, y + 15 * scale), (x - 2 * scale, y + 21 * scale)],
+                fill=(100, 50, 50),
+                width=2,
+            )
+            draw.line(
+                [(x - 8 * scale, y + 21 * scale), (x - 2 * scale, y + 15 * scale)],
+                fill=(100, 50, 50),
+                width=2,
+            )
+            draw.line(
+                [(x + 2 * scale, y + 15 * scale), (x + 8 * scale, y + 21 * scale)],
+                fill=(100, 50, 50),
+                width=2,
+            )
+            draw.line(
+                [(x + 2 * scale, y + 21 * scale), (x + 8 * scale, y + 15 * scale)],
+                fill=(100, 50, 50),
+                width=2,
+            )
+
         # Name
         name_text = spieler.name[:12]  # Maximal 12 Zeichen
         bbox = draw.textbbox((0, 0), name_text, font=self._font)
         text_width = bbox[2] - bbox[0]
-        
+
         # Hintergrund für Namen
-        draw.rectangle([
-            x - text_width // 2 - 3, y + 35,
-            x + text_width // 2 + 3, y + 52
-        ], fill=(0, 0, 0, 180))
-        
+        draw.rectangle(
+            [x - text_width // 2 - 3, y + 35, x + text_width // 2 + 3, y + 52],
+            fill=(0, 0, 0, 180),
+        )
+
         draw.text(
             (x - text_width // 2, y + 37),
             name_text,
             fill=(255, 255, 255) if spieler.ist_am_leben else (150, 150, 150),
-            font=self._font
+            font=self._font,
         )
-    
+
     def _apply_hinweis_farbe(
-        self, 
-        basis_farbe: Tuple[int, int, int], 
-        hinweis_typ: str, 
-        intensitaet: float
+        self, basis_farbe: Tuple[int, int, int], hinweis_typ: str, intensitaet: float
     ) -> Tuple[int, int, int]:
         """Wendet Hinweis-Färbung auf die Basis-Farbe an"""
         hinweis_farben = {
-            'augen_flackern': (200, 50, 50),
-            'schatten': (30, 30, 40),
-            'mond_schein': (150, 150, 220),
-            'nervoes': (200, 180, 100),
-            'gluehen': (150, 100, 200),
-            'selbst_verdaechtigung': (220, 100, 50),
+            "augen_flackern": (200, 50, 50),
+            "schatten": (30, 30, 40),
+            "mond_schein": (150, 150, 220),
+            "nervoes": (200, 180, 100),
+            "gluehen": (150, 100, 200),
+            "selbst_verdaechtigung": (220, 100, 50),
         }
-        
+
         hinweis_farbe = hinweis_farben.get(hinweis_typ, basis_farbe)
-        
+
         # Mische Farben basierend auf Intensität
         r = int(basis_farbe[0] * (1 - intensitaet) + hinweis_farbe[0] * intensitaet)
         g = int(basis_farbe[1] * (1 - intensitaet) + hinweis_farbe[1] * intensitaet)
         b = int(basis_farbe[2] * (1 - intensitaet) + hinweis_farbe[2] * intensitaet)
-        
+
         return (min(255, r), min(255, g), min(255, b))
-    
+
     def _render_hinweis_effekt(
-        self, 
-        img: Image.Image, 
-        draw: ImageDraw.Draw, 
-        x: float, 
-        y: float, 
-        hinweis: Tuple[str, float]
+        self,
+        img: Image.Image,
+        draw: ImageDraw.Draw,
+        x: float,
+        y: float,
+        hinweis: Tuple[str, float],
     ):
         """Rendert visuelle Hinweis-Effekte um einen Spieler"""
         hinweis_typ, intensitaet = hinweis
-        
-        if hinweis_typ == 'augen_flackern':
+
+        if hinweis_typ == "augen_flackern":
             # Rotes Glühen um Kopf
             kopf_y = y - 40
             for i in range(int(5 * intensitaet), 0, -1):
                 alpha = int(50 * intensitaet * (1 - i / 5))
-                glow = Image.new('RGBA', img.size, (0, 0, 0, 0))
+                glow = Image.new("RGBA", img.size, (0, 0, 0, 0))
                 glow_draw = ImageDraw.Draw(glow)
-                glow_draw.ellipse([
-                    x - 15 - i * 3, kopf_y - 15 - i * 3,
-                    x + 15 + i * 3, kopf_y + 15 + i * 3
-                ], fill=(200, 50, 50, alpha))
+                glow_draw.ellipse(
+                    [
+                        x - 15 - i * 3,
+                        kopf_y - 15 - i * 3,
+                        x + 15 + i * 3,
+                        kopf_y + 15 + i * 3,
+                    ],
+                    fill=(200, 50, 50, alpha),
+                )
                 img.paste(Image.alpha_composite(img, glow))
-                
-        elif hinweis_typ == 'schatten':
+
+        elif hinweis_typ == "schatten":
             # Dunkler Schatten hinter Spieler
-            schatten = Image.new('RGBA', img.size, (0, 0, 0, 0))
+            schatten = Image.new("RGBA", img.size, (0, 0, 0, 0))
             schatten_draw = ImageDraw.Draw(schatten)
-            schatten_draw.ellipse([
-                x - 30, y - 50,
-                x + 40, y + 30
-            ], fill=(0, 0, 0, int(100 * intensitaet)))
+            schatten_draw.ellipse(
+                [x - 30, y - 50, x + 40, y + 30], fill=(0, 0, 0, int(100 * intensitaet))
+            )
             img.paste(Image.alpha_composite(img, schatten))
-            
-        elif hinweis_typ == 'mond_schein':
+
+        elif hinweis_typ == "mond_schein":
             # Bläuliches Mondlicht von oben
-            beam = Image.new('RGBA', img.size, (0, 0, 0, 0))
+            beam = Image.new("RGBA", img.size, (0, 0, 0, 0))
             beam_draw = ImageDraw.Draw(beam)
             beam_punkte = [
                 (x - 5, 0),
@@ -482,50 +576,52 @@ class VillageRenderer:
             ]
             beam_draw.polygon(beam_punkte, fill=(150, 150, 220, int(60 * intensitaet)))
             img.paste(Image.alpha_composite(img, beam))
-            
-        elif hinweis_typ == 'gluehen':
+
+        elif hinweis_typ == "gluehen":
             # Mystisches Glühen
             for i in range(int(8 * intensitaet), 0, -1):
                 alpha = int(40 * intensitaet * (1 - i / 8))
-                glow = Image.new('RGBA', img.size, (0, 0, 0, 0))
+                glow = Image.new("RGBA", img.size, (0, 0, 0, 0))
                 glow_draw = ImageDraw.Draw(glow)
-                glow_draw.ellipse([
-                    x - 20 - i * 4, y - 30 - i * 4,
-                    x + 20 + i * 4, y + 20 + i * 4
-                ], fill=(150, 100, 200, alpha))
+                glow_draw.ellipse(
+                    [x - 20 - i * 4, y - 30 - i * 4, x + 20 + i * 4, y + 20 + i * 4],
+                    fill=(150, 100, 200, alpha),
+                )
                 img.paste(Image.alpha_composite(img, glow))
-                
-        elif hinweis_typ == 'selbst_verdaechtigung':
+
+        elif hinweis_typ == "selbst_verdaechtigung":
             # Orange/rotes warnendes Glühen
             for i in range(int(6 * intensitaet), 0, -1):
                 alpha = int(60 * intensitaet * (1 - i / 6))
-                glow = Image.new('RGBA', img.size, (0, 0, 0, 0))
+                glow = Image.new("RGBA", img.size, (0, 0, 0, 0))
                 glow_draw = ImageDraw.Draw(glow)
-                glow_draw.ellipse([
-                    x - 25 - i * 3, y - 35 - i * 3,
-                    x + 25 + i * 3, y + 25 + i * 3
-                ], fill=(220, 100, 50, alpha))
+                glow_draw.ellipse(
+                    [x - 25 - i * 3, y - 35 - i * 3, x + 25 + i * 3, y + 25 + i * 3],
+                    fill=(220, 100, 50, alpha),
+                )
                 img.paste(Image.alpha_composite(img, glow))
-    
+
     def _render_nebel(self, img: Image.Image):
         """Rendert Nebel-Effekt"""
-        nebel = Image.new('RGBA', img.size, (0, 0, 0, 0))
+        nebel = Image.new("RGBA", img.size, (0, 0, 0, 0))
         nebel_draw = ImageDraw.Draw(nebel)
-        
+
         for _ in range(20):
             x = random.randint(0, self.width)
             y = random.randint(self.height // 2, self.height)
             w = random.randint(100, 300)
             h = random.randint(30, 80)
             alpha = random.randint(20, 50)
-            nebel_draw.ellipse([x - w, y - h, x + w, y + h], fill=(150, 150, 160, alpha))
-        
+            nebel_draw.ellipse(
+                [x - w, y - h, x + w, y + h], fill=(150, 150, 160, alpha)
+            )
+
         nebel = nebel.filter(ImageFilter.GaussianBlur(radius=20))
         img.paste(Image.alpha_composite(img, nebel))
-    
+
     def _render_nacht_overlay(self, img: Image.Image):
         """Rendert ein dunkles Nacht-Overlay"""
-        overlay = Image.new('RGBA', img.size, (0, 0, 30, 40))
+        overlay = Image.new("RGBA", img.size, (0, 0, 30, 40))
         img.paste(Image.alpha_composite(img, overlay))
 
 
@@ -535,6 +631,7 @@ class VillageRenderer:
 
 _renderer = None
 
+
 def get_renderer() -> VillageRenderer:
     """Singleton für den Renderer"""
     global _renderer
@@ -543,47 +640,51 @@ def get_renderer() -> VillageRenderer:
     return _renderer
 
 
-def render_village_for_room(raum_id: int, hinweise: Dict[int, Tuple[str, float]] = None) -> str:
+def render_village_for_room(
+    raum_id: int, hinweise: Dict[int, Tuple[str, float]] = None
+) -> str:
     """
     Rendert das Dorf für einen Raum und gibt Base64-Bild zurück.
-    
+
     Args:
         raum_id: ID des Raums
         hinweise: Optional - Dict von spieler_id zu (hinweis_typ, intensität)
-        
+
     Returns:
         Base64-kodiertes PNG für HTML img src
     """
     from models import Raum, Spieler
-    
+
     raum = Raum.query.get(raum_id)
     if not raum:
         return None
-    
+
     # Hole alle Spieler (KEINE Rollen-Information!)
     spieler_db = Spieler.query.filter_by(raum_id=raum_id, ist_erzaehler=False).all()
-    
+
     spieler_visuals = []
     for i, s in enumerate(spieler_db):
-        spieler_visuals.append(SpielerVisual(
-            id=s.id,
-            name=s.name,
-            sitzplatz=s.sitzplatz if s.sitzplatz is not None else i,
-            ist_am_leben=s.ist_am_leben,
-        ))
-    
+        spieler_visuals.append(
+            SpielerVisual(
+                id=s.id,
+                name=s.name,
+                sitzplatz=s.sitzplatz if s.sitzplatz is not None else i,
+                ist_am_leben=s.ist_am_leben,
+            )
+        )
+
     # Bestimme Phase
-    phase = 'nacht' if 'nacht' in raum.aktuelle_phase.lower() else 'tag'
-    if 'daemmer' in raum.aktuelle_phase.lower():
-        phase = 'daemmerung'
-    
+    phase = "nacht" if "nacht" in raum.aktuelle_phase.lower() else "tag"
+    if "daemmer" in raum.aktuelle_phase.lower():
+        phase = "daemmerung"
+
     szene = DorfSzene(
         spieler=spieler_visuals,
         phase=phase,
         runde=raum.runde,
         aktive_hinweise=hinweise or {},
     )
-    
+
     renderer = get_renderer()
     return renderer.render_szene_base64(szene)
 
@@ -600,27 +701,27 @@ def generate_test_village() -> str:
         SpielerVisual(id=7, name="Klaus", sitzplatz=6, ist_am_leben=True),
         SpielerVisual(id=8, name="Sophie", sitzplatz=7, ist_am_leben=True),
     ]
-    
+
     szene = DorfSzene(
         spieler=test_spieler,
-        phase='nacht',
+        phase="nacht",
         runde=2,
         aktive_hinweise={
-            1: ('augen_flackern', 0.7),
-            4: ('schatten', 0.5),
-            6: ('selbst_verdaechtigung', 0.8),
+            1: ("augen_flackern", 0.7),
+            4: ("schatten", 0.5),
+            6: ("selbst_verdaechtigung", 0.8),
         },
     )
-    
+
     renderer = get_renderer()
     return renderer.render_szene_base64(szene)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # Test-Rendering
     print("Generiere Test-Bild...")
     base64_img = generate_test_village()
-    
+
     # Speichere als HTML zum Testen
     html = f"""
     <!DOCTYPE html>
@@ -631,10 +732,8 @@ if __name__ == '__main__':
     </body>
     </html>
     """
-    
-    with open('village_test.html', 'w') as f:
+
+    with open("village_test.html", "w") as f:
         f.write(html)
-    
+
     print("Test-Bild gespeichert als village_test.html")
-
-

--- a/village_renderer.py
+++ b/village_renderer.py
@@ -122,9 +122,10 @@ class VillageRenderer:
         
         # 5. Spieler rendern (von hinten nach vorne für korrekte Überlappung)
         spieler_sortiert = self._sortiere_spieler_fuer_rendering(szene.spieler)
+        total_spieler = max(len(szene.spieler), 8)
         for spieler in spieler_sortiert:
             hinweis = szene.aktive_hinweise.get(spieler.id)
-            self._render_spieler(img, draw, spieler, szene.phase, hinweis)
+            self._render_spieler(img, draw, spieler, szene.phase, hinweis, total_spieler)
         
         # 6. Atmosphären-Effekte
         if szene.wetter == 'nebel':
@@ -320,24 +321,29 @@ class VillageRenderer:
         return sorted(spieler, key=y_position)
     
     def _render_spieler(
-        self, 
-        img: Image.Image, 
-        draw: ImageDraw.Draw, 
-        spieler: SpielerVisual, 
+        self,
+        img: Image.Image,
+        draw: ImageDraw.Draw,
+        spieler: SpielerVisual,
         phase: str,
-        hinweis: Optional[Tuple[str, float]] = None
+        hinweis: Optional[Tuple[str, float]] = None,
+        total_spieler: int = 8
     ):
         """Rendert einen einzelnen Spieler"""
-        anzahl = max(8, 1)  # Mindestens 8 Positionen
+        anzahl = max(total_spieler, 8)
         winkel = (spieler.sitzplatz / anzahl) * 2 * math.pi - math.pi / 2
-        
+
         cx, cy = CIRCLE_CENTER
-        x = cx + math.cos(winkel) * CIRCLE_RADIUS
-        y = cy + math.sin(winkel) * CIRCLE_RADIUS * ISO_SCALE_Y
+        tiefenfaktor = 0.65 + 0.35 * ((math.sin(winkel) + 1) / 2)
+        radius = CIRCLE_RADIUS * (0.8 + 0.2 * tiefenfaktor)
+        x = cx + math.cos(winkel) * radius
+        y = cy + math.sin(winkel) * radius * ISO_SCALE_Y
+
+        scale = 0.7 + 0.5 * tiefenfaktor
         
         # Schatten
         if spieler.ist_am_leben:
-            draw.ellipse([x - 15, y + 25, x + 15, y + 35], fill=(0, 0, 0, 80))
+            draw.ellipse([x - 15 * scale, y + 25 * scale, x + 15 * scale, y + 35 * scale], fill=(0, 0, 0, 80))
         
         # Körper-Farbe basierend auf Zustand
         if not spieler.ist_am_leben:
@@ -355,37 +361,37 @@ class VillageRenderer:
             
             # Körper (Robe)
             robe_punkte = [
-                (x - 12, y + 25),  # Unten links
-                (x - 15, y - 5),   # Taille links
-                (x - 8, y - 25),   # Schulter links
-                (x, y - 30),       # Kopf-Ansatz
-                (x + 8, y - 25),   # Schulter rechts
-                (x + 15, y - 5),   # Taille rechts
-                (x + 12, y + 25),  # Unten rechts
+                (x - 12 * scale, y + 25 * scale),  # Unten links
+                (x - 15 * scale, y - 5 * scale),   # Taille links
+                (x - 8 * scale, y - 25 * scale),   # Schulter links
+                (x, y - 30 * scale),       # Kopf-Ansatz
+                (x + 8 * scale, y - 25 * scale),   # Schulter rechts
+                (x + 15 * scale, y - 5 * scale),   # Taille rechts
+                (x + 12 * scale, y + 25 * scale),  # Unten rechts
             ]
             draw.polygon(robe_punkte, fill=koerper_farbe, outline=(50, 50, 60))
-            
+
             # Kopf
-            kopf_y = y - 40
-            draw.ellipse([x - 10, kopf_y - 10, x + 10, kopf_y + 10], fill=(220, 185, 155))
+            kopf_y = y - 40 * scale
+            draw.ellipse([x - 10 * scale, kopf_y - 10 * scale, x + 10 * scale, kopf_y + 10 * scale], fill=(220, 185, 155))
             
             # Augen (schauen zum Feuer)
             feuer_richtung = math.atan2(cy - kopf_y, cx - x)
-            auge_offset_x = math.cos(feuer_richtung) * 3
-            draw.ellipse([x - 4 + auge_offset_x, kopf_y - 2, x - 2 + auge_offset_x, kopf_y + 2], fill=(40, 40, 40))
-            draw.ellipse([x + 2 + auge_offset_x, kopf_y - 2, x + 4 + auge_offset_x, kopf_y + 2], fill=(40, 40, 40))
+            auge_offset_x = math.cos(feuer_richtung) * 3 * scale
+            draw.ellipse([x - 4 * scale + auge_offset_x, kopf_y - 2 * scale, x - 2 * scale + auge_offset_x, kopf_y + 2 * scale], fill=(40, 40, 40))
+            draw.ellipse([x + 2 * scale + auge_offset_x, kopf_y - 2 * scale, x + 4 * scale + auge_offset_x, kopf_y + 2 * scale], fill=(40, 40, 40))
             
             # Hinweis-Glow um Spieler
             if hinweis:
                 self._render_hinweis_effekt(img, draw, x, y, hinweis)
         else:
             # Toter Spieler - liegend
-            draw.ellipse([x - 20, y + 10, x + 20, y + 30], fill=koerper_farbe)
+            draw.ellipse([x - 20 * scale, y + 10 * scale, x + 20 * scale, y + 30 * scale], fill=koerper_farbe)
             # X über den Augen
-            draw.line([(x - 8, y + 15), (x - 2, y + 21)], fill=(100, 50, 50), width=2)
-            draw.line([(x - 8, y + 21), (x - 2, y + 15)], fill=(100, 50, 50), width=2)
-            draw.line([(x + 2, y + 15), (x + 8, y + 21)], fill=(100, 50, 50), width=2)
-            draw.line([(x + 2, y + 21), (x + 8, y + 15)], fill=(100, 50, 50), width=2)
+            draw.line([(x - 8 * scale, y + 15 * scale), (x - 2 * scale, y + 21 * scale)], fill=(100, 50, 50), width=2)
+            draw.line([(x - 8 * scale, y + 21 * scale), (x - 2 * scale, y + 15 * scale)], fill=(100, 50, 50), width=2)
+            draw.line([(x + 2 * scale, y + 15 * scale), (x + 8 * scale, y + 21 * scale)], fill=(100, 50, 50), width=2)
+            draw.line([(x + 2 * scale, y + 21 * scale), (x + 8 * scale, y + 15 * scale)], fill=(100, 50, 50), width=2)
         
         # Name
         name_text = spieler.name[:12]  # Maximal 12 Zeichen


### PR DESCRIPTION
## Summary
- build phase-to-role mapping dynamically from the role registry with umlaut-safe normalization and legacy fallback
- add regression tests to ensure registry-derived mapping covers umlaut roles and only uses known phases

## Testing
- python -m unittest discover -s tests -p "test_*.py"


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69590bdd67348331937ea053ed28bb12)